### PR TITLE
ubx: fix #63: NAV-SAT/ SVINFO parser bug

### DIFF
--- a/src/ubx.h
+++ b/src/ubx.h
@@ -455,13 +455,11 @@ typedef struct {
 typedef struct {
 	uint8_t chn;            /**< Channel number, 255 for SVs not assigned to a channel */
 	uint8_t svid;           /**< Satellite ID */
-	uint8_t flags;
-	uint8_t quality;
+	uint8_t flags;          /**< svUsed, diffCorr, orbitAvail, orbitEph, unhealthy, orbitAlm, orbitAop, smoothed */
+	uint8_t quality;        /**< 0: no signal, 1: search, 2: aquited, 3: unusable, 5-7: locked */
+	uint8_t cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
 	int8_t  elev;           /**< Elevation [deg] */
 	int16_t azim;           /**< Azimuth [deg] */
-	uint8_t cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	uint8_t snr;            /**< Signal to Noise Ratio */
-	uint8_t prn;            /**< Psuedo Random Number SBAS code, [120-144] */
 	int32_t prRes;          /**< Pseudo range residual [cm] */
 } ubx_payload_rx_nav_svinfo_part2_t;
 
@@ -477,10 +475,9 @@ typedef struct {
 typedef struct {
 	uint8_t  gnssId;         /**< GNSS identifier */
 	uint8_t  svId;           /**< Satellite ID */
+	uint8_t  cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
 	int8_t   elev;           /**< Elevation [deg] range: +/-90 */
 	int16_t  azim;           /**< Azimuth [deg] range: 0-360 */
-	uint8_t  cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	uint8_t  prn;            /**< Psuedo Random Number SBAS code, [120-144] */
 	int16_t  prRes;          /**< Pseudo range residual [0.1 m] */
 	uint32_t flags;
 } ubx_payload_rx_nav_sat_part2_t;


### PR DESCRIPTION
To maintain backwards compatibility with the GPS_STATUS MAVLink message, the `svId` was also added to `satellite_info.prn`.

Because `satellite_info.svid` is only 8 bit wide, the new `gnssId:svId` format used in the NAV-SAT message does not fit into the uORB topic. Therefore the data from NAV-SAT is converted to the old format from NAV-SVINFO.