### PR TITLE
ubx: change uart2_baudrate to 230400

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -489,7 +489,7 @@ int GPSDriverUBX::configureDevice()
 		return -1;
 	}
 
-	int uart2_baudrate = 460800;
+	int uart2_baudrate = 230400;
 
 	if (_mode == UBXMode::RoverWithMovingBase) {
 		UBX_DEBUG("Configuring UART2 for rover");


### PR DESCRIPTION
The uart2 is used to connect two GPS to enable GPS heading measurements.

Lowering this baudrate has shown higher SNR.
