### PR TITLE
Implement new parameter for GNSS system selection

### DIFF
--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -942,9 +942,9 @@ int GPSDriverAshtech::waitForReply(NMEACommand command, const unsigned timeout)
 	return _command_state == NMEACommandState::received ? 0 : -1;
 }
 
-int GPSDriverAshtech::configure(unsigned &baudrate, OutputMode output_mode)
+int GPSDriverAshtech::configure(unsigned &baudrate, const GPSConfig &config)
 {
-	_output_mode = output_mode;
+	_output_mode = config.output_mode;
 	_correction_output_activated = false;
 	_configure_done = false;
 
@@ -1069,7 +1069,7 @@ int GPSDriverAshtech::configure(unsigned &baudrate, OutputMode output_mode)
 	// Enable dual antenna mode (2: both antennas are L1/L2 GNSS capable, flex mode, avoids the need to determine
 	// the baseline length through a prior calibration stage)
 	// Needs to be set before other commands
-	const bool use_dual_mode = output_mode == OutputMode::GPS && _board == AshtechBoard::trimble_mb_two;
+	const bool use_dual_mode = _output_mode == OutputMode::GPS && _board == AshtechBoard::trimble_mb_two;
 
 	if (use_dual_mode) {
 		ASH_DEBUG("Enabling DUO mode");
@@ -1118,7 +1118,7 @@ int GPSDriverAshtech::configure(unsigned &baudrate, OutputMode output_mode)
 	}
 
 
-	if (output_mode == OutputMode::RTCM && _board == AshtechBoard::trimble_mb_two) {
+	if (_output_mode == OutputMode::RTCM && _board == AshtechBoard::trimble_mb_two) {
 		SurveyInStatus status{};
 		status.latitude = status.longitude = (double)NAN;
 		status.altitude = NAN;

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -59,7 +59,7 @@ public:
 
 	virtual ~GPSDriverAshtech();
 
-	int configure(unsigned &baudrate, OutputMode output_mode) override;
+	int configure(unsigned &baudrate, const GPSConfig &config) override;
 
 	int receive(unsigned timeout) override;
 

--- a/src/emlid_reach.cpp
+++ b/src/emlid_reach.cpp
@@ -78,11 +78,11 @@ GPSDriverEmlidReach::GPSDriverEmlidReach(GPSCallbackPtr callback, void *callback
 
 
 int
-GPSDriverEmlidReach::configure(unsigned &baudrate, OutputMode output_mode)
+GPSDriverEmlidReach::configure(unsigned &baudrate, const GPSConfig &config)
 {
 	// TODO RTK
-	if (output_mode != OutputMode::GPS) {
-		GPS_WARN("EMLIDREACH: Unsupported Output Mode %i", (int)output_mode);
+	if (config.output_mode != OutputMode::GPS) {
+		GPS_WARN("EMLIDREACH: Unsupported Output Mode %i", (int)config.output_mode);
 		return -1;
 	}
 

--- a/src/emlid_reach.h
+++ b/src/emlid_reach.h
@@ -147,7 +147,7 @@ public:
 	virtual ~GPSDriverEmlidReach() = default;
 
 	int receive(unsigned timeout) override;
-	int configure(unsigned &baudrate, OutputMode output_mode) override;
+	int configure(unsigned &baudrate, const GPSConfig &config) override;
 
 private:
 

--- a/src/femtomes.cpp
+++ b/src/femtomes.cpp
@@ -322,11 +322,11 @@ int GPSDriverFemto::writeAckedCommandFemto(const char *command, const char *repl
 	return -1;
 }
 
-int GPSDriverFemto::configure(unsigned &baudrate, OutputMode output_mode)
+int GPSDriverFemto::configure(unsigned &baudrate, const GPSConfig &config)
 {
 
-	if (output_mode != OutputMode::GPS) {
-		FEMTO_DEBUG("Femto: Unsupported Output Mode %i", (int)output_mode);
+	if (config.output_mode != OutputMode::GPS) {
+		FEMTO_DEBUG("Femto: Unsupported Output Mode %i", (int)config.output_mode);
 		return -1;
 	}
 

--- a/src/femtomes.h
+++ b/src/femtomes.h
@@ -148,7 +148,7 @@ public:
 	virtual ~GPSDriverFemto() = default;
 
 	int receive(unsigned timeout) override;
-	int configure(unsigned &baudrate, OutputMode output_mode) override;
+	int configure(unsigned &baudrate, const GPSConfig &config) override;
 
 private:
 

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -161,6 +161,24 @@ public:
 		SPI
 	};
 
+	/**
+	 * Bitmask for GPS_1_GNSS and GPS_2_GNSS
+	 * No bits set should keep the receiver's default config
+	 */
+	enum class GNSSSystemsMask : int32_t {
+		RECEIVER_DEFAULTS = 0,
+		ENABLE_GPS =        1 << 0,
+		ENABLE_SBAS =       1 << 1,
+		ENABLE_GALILEO =    1 << 2,
+		ENABLE_BEIDOU =     1 << 3,
+		ENABLE_GLONASS =    1 << 4
+	};
+
+	struct GPSConfig {
+		OutputMode output_mode;
+		GNSSSystemsMask gnss_systems;
+	};
+
 
 	GPSHelper(GPSCallbackPtr callback, void *callback_user);
 	virtual ~GPSHelper() = default;
@@ -169,9 +187,10 @@ public:
 	 * configure the device
 	 * @param baud Input and output parameter: if set to 0, the baudrate will be automatically detected and set to
 	 *             the detected baudrate. If not 0, a fixed baudrate is used.
+	 * @param config GPS Config
 	 * @return 0 on success, <0 otherwise
 	 */
-	virtual int configure(unsigned &baud, OutputMode output_mode) = 0;
+	virtual int configure(unsigned &baud, const GPSConfig &config) = 0;
 
 	/**
 	 * receive & handle new data from the device
@@ -278,3 +297,8 @@ protected:
 
 	uint64_t _interval_rate_start{0};
 };
+
+inline bool operator&(GPSHelper::GNSSSystemsMask a, GPSHelper::GNSSSystemsMask b)
+{
+	return static_cast<int32_t>(a) & static_cast<int32_t>(b);
+}

--- a/src/mtk.cpp
+++ b/src/mtk.cpp
@@ -55,10 +55,10 @@ GPSDriverMTK::GPSDriverMTK(GPSCallbackPtr callback, void *callback_user, sensor_
 }
 
 int
-GPSDriverMTK::configure(unsigned &baudrate, OutputMode output_mode)
+GPSDriverMTK::configure(unsigned &baudrate, const GPSConfig &config)
 {
-	if (output_mode != OutputMode::GPS) {
-		GPS_WARN("MTK: Unsupported Output Mode %i", (int)output_mode);
+	if (config.output_mode != OutputMode::GPS) {
+		GPS_WARN("MTK: Unsupported Output Mode %i", (int)config.output_mode);
 		return -1;
 	}
 

--- a/src/mtk.h
+++ b/src/mtk.h
@@ -92,7 +92,7 @@ public:
 	virtual ~GPSDriverMTK() = default;
 
 	int receive(unsigned timeout) override;
-	int configure(unsigned &baudrate, OutputMode output_mode) override;
+	int configure(unsigned &baudrate, const GPSConfig &config) override;
 
 private:
 	/**

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -73,16 +73,16 @@ GPSDriverSBF::~GPSDriverSBF()
 }
 
 int
-GPSDriverSBF::configure(unsigned &baudrate, OutputMode output_mode)
+GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 {
 	_configured = false;
 
 	setBaudrate(SBF_TX_CFG_PRT_BAUDRATE);
 	baudrate = SBF_TX_CFG_PRT_BAUDRATE;
 
-	_output_mode = output_mode;
+	_output_mode = config.output_mode;
 
-	if (output_mode != OutputMode::RTCM) {
+	if (_output_mode != OutputMode::RTCM) {
 		sendMessage(SBF_CONFIG_FORCE_INPUT);
 	}
 

--- a/src/sbf.h
+++ b/src/sbf.h
@@ -316,7 +316,7 @@ public:
 	virtual ~GPSDriverSBF() override;
 
 	int receive(unsigned timeout) override;
-	int configure(unsigned &baudrate, OutputMode output_mode) override;
+	int configure(unsigned &baudrate, const GPSConfig &config) override;
 	int reset(GPSRestartType restart_type) override;
 
 private:

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -89,18 +89,18 @@ GPSDriverUBX::~GPSDriverUBX()
 }
 
 int
-GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
+GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 {
 	_configured = false;
-	_output_mode = output_mode;
+	_output_mode = config.output_mode;
 
 	ubx_payload_tx_cfg_prt_t cfg_prt[2];
 
-	uint16_t out_proto_mask = output_mode == OutputMode::GPS ?
+	uint16_t out_proto_mask = _output_mode == OutputMode::GPS ?
 				  UBX_TX_CFG_PRT_OUTPROTOMASK_GPS :
 				  UBX_TX_CFG_PRT_OUTPROTOMASK_RTCM;
 
-	uint16_t in_proto_mask = output_mode == OutputMode::GPS ?
+	uint16_t in_proto_mask = _output_mode == OutputMode::GPS ?
 				 UBX_TX_CFG_PRT_INPROTOMASK_GPS :
 				 UBX_TX_CFG_PRT_INPROTOMASK_RTCM;
 
@@ -137,12 +137,12 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_DATABITS, 0, cfg_valset_msg_size);
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_PARITY, 0, cfg_valset_msg_size);
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, output_mode == OutputMode::GPS ? 1 : 0,
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, _output_mode == OutputMode::GPS ? 1 : 0,
 					   cfg_valset_msg_size);
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0, cfg_valset_msg_size);
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
 
-			if (output_mode == OutputMode::RTCM) {
+			if (_output_mode == OutputMode::RTCM) {
 				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
 			}
 
@@ -151,12 +151,12 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 
 			// USB
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_RTCM3X, output_mode == OutputMode::GPS ? 1 : 0,
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_RTCM3X, _output_mode == OutputMode::GPS ? 1 : 0,
 					   cfg_valset_msg_size);
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_NMEA, 0, cfg_valset_msg_size);
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_UBX, 1, cfg_valset_msg_size);
 
-			if (output_mode == OutputMode::RTCM) {
+			if (_output_mode == OutputMode::RTCM) {
 				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X, 1, cfg_valset_msg_size);
 			}
 
@@ -252,10 +252,10 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_ENABLED, 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_MAXFF, 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X, output_mode == OutputMode::GPS ? 1 : 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X, _output_mode == OutputMode::GPS ? 1 : 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_NMEA, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X, output_mode == OutputMode::GPS ? 0 : 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X, _output_mode == OutputMode::GPS ? 0 : 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA, 0, cfg_valset_msg_size);
 
 		bool cfg_valset_success = false;
@@ -321,7 +321,7 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 	}
 
 
-	if (output_mode != OutputMode::GPS) {
+	if (_output_mode != OutputMode::GPS) {
 		// RTCM mode force stationary dynamic model
 		_dyn_model = 2;
 	}
@@ -339,7 +339,7 @@ GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 		return ret;
 	}
 
-	if (output_mode == OutputMode::RTCM) {
+	if (_output_mode == OutputMode::RTCM) {
 		if (restartSurveyIn() < 0) {
 			return -1;
 		}

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -101,6 +101,7 @@
 #define UBX_ID_CFG_RST        0x04
 #define UBX_ID_CFG_SBAS       0x16
 #define UBX_ID_CFG_TMODE3     0x71 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_GNSS       0x3E
 #define UBX_ID_CFG_VALSET     0x8A
 #define UBX_ID_CFG_VALGET     0x8B
 #define UBX_ID_CFG_VALDEL     0x8C
@@ -151,6 +152,7 @@
 #define UBX_MSG_CFG_RST       ((UBX_CLASS_CFG) | UBX_ID_CFG_RST << 8)
 #define UBX_MSG_CFG_SBAS      ((UBX_CLASS_CFG) | UBX_ID_CFG_SBAS << 8)
 #define UBX_MSG_CFG_TMODE3    ((UBX_CLASS_CFG) | UBX_ID_CFG_TMODE3 << 8)
+#define UBX_MSG_CFG_GNSS      ((UBX_CLASS_CFG) | UBX_ID_CFG_GNSS << 8)
 #define UBX_MSG_CFG_VALGET    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALGET << 8)
 #define UBX_MSG_CFG_VALSET    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALSET << 8)
 #define UBX_MSG_CFG_VALDEL    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALDEL << 8)
@@ -225,6 +227,34 @@
 #define UBX_TX_CFG_RST_BBR_MODE_COLD_START      0xFFFF
 #define UBX_TX_CFG_RST_MODE_HARDWARE            0
 #define UBX_TX_CFG_RST_MODE_SOFTWARE            1
+
+/* TX CFG-GNSS message contents
+ */
+#define UBX_TX_CFG_GNSS_GNSSID_GPS              0       /**< gnssId of GPS */
+#define UBX_TX_CFG_GNSS_GNSSID_SBAS             1       /**< gnssId of SBAS */
+#define UBX_TX_CFG_GNSS_GNSSID_GALILEO          2       /**< gnssId of Galileo */
+#define UBX_TX_CFG_GNSS_GNSSID_BEIDOU           3       /**< gnssId of BeiDou */
+#define UBX_TX_CFG_GNSS_GNSSID_IMES             4       /**< gnssId of IMES */
+#define UBX_TX_CFG_GNSS_GNSSID_QZSS             5       /**< gnssId of QZSS */
+#define UBX_TX_CFG_GNSS_GNSSID_GLONASS          6       /**< gnssId of GLONASS */
+#define UBX_TX_CFG_GNSS_FLAGS_ENABLE            0x00000001  /**< Enable this GNSS system */
+#define UBX_TX_CFG_GNSS_FLAGS_GPS_L1CA          0x00010000  /**< GPS: Use L1C/A Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_GPS_L2C           0x00100000  /**< GPS: Use L2C Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_GPS_L5            0x00200000  /**< GPS: Use L5 Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_SBAS_L1CA         0x00010000  /**< SBAS: Use L1C/A Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_GALILEO_E1        0x00010000  /**< Galileo: Use E1 Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_GALILEO_E5A       0x00100000  /**< Galileo: Use E5a Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_GALILEO_E5B       0x00200000  /**< Galileo: Use E5b Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_BEIDOU_B1I        0x00010000  /**< BeiDou: Use B1I Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_BEIDOU_B2I        0x00100000  /**< BeiDou: Use B2I Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_BEIDOU_B2A        0x00800000  /**< BeiDou: Use B2A Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_IMES_L1           0x00010000  /**< IMES: Use L1 Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L1CA         0x00010000  /**< QZSS: Use L1C/A Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L1S          0x00040000  /**< QZSS: Use L1S Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L2C          0x00100000  /**< QZSS: Use L2C Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L5           0x00200000  /**< QZSS: Use L5 Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_GLONASS_L1        0x00010000  /**< GLONASS: Use L1 Signal */
+#define UBX_TX_CFG_GNSS_FLAGS_GLONASS_L2        0x00100000  /**< GLONASS: Use L2 Signal */
 
 /* Key ID's for CFG-VAL{GET,SET,DEL} */
 #define UBX_CFG_KEY_CFG_UART1_BAUDRATE          0x40520001
@@ -320,6 +350,25 @@
 
 #define UBX_CFG_KEY_SPI_ENABLED                 0x10640006
 #define UBX_CFG_KEY_SPI_MAXFF                   0x20640001
+
+#define UBX_CFG_KEY_SIGNAL_GPS_ENA              0x1031001f  /**< GPS enable */
+#define UBX_CFG_KEY_SIGNAL_GPS_L1CA_ENA         0x10310001  /**< GPS L1C/A */
+#define UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA          0x10310003  /**< GPS L2C (only on u-blox F9 platform products) */
+#define UBX_CFG_KEY_SIGNAL_SBAS_ENA             0x10310020  /**< SBAS enable */
+#define UBX_CFG_KEY_SIGNAL_SBAS_L1CA_ENA        0x10310005  /**< SBAS L1C/A */
+#define UBX_CFG_KEY_SIGNAL_GAL_ENA              0x10310021  /**< Galileo enable */
+#define UBX_CFG_KEY_SIGNAL_GAL_E1_ENA           0x10310007  /**< Galileo E1 */
+#define UBX_CFG_KEY_SIGNAL_GAL_E5B_ENA          0x1031000a  /**< Galileo E5b (only on u-blox F9 platform products) */
+#define UBX_CFG_KEY_SIGNAL_BDS_ENA              0x10310022  /**< BeiDou Enable */
+#define UBX_CFG_KEY_SIGNAL_BDS_B1_ENA           0x1031000d  /**< BeiDou B1I */
+#define UBX_CFG_KEY_SIGNAL_BDS_B2_ENA           0x1031000e  /**< BeiDou B2I (only on u-blox F9 platform products) */
+#define UBX_CFG_KEY_SIGNAL_QZSS_ENA             0x10310024  /**< QZSS enable */
+#define UBX_CFG_KEY_SIGNAL_QZSS_L1CA_ENA        0x10310012  /**< QZSS L1C/A */
+#define UBX_CFG_KEY_SIGNAL_QZSS_L1S_ENA         0x10310014  /**< QZSS L1S */
+#define UBX_CFG_KEY_SIGNAL_QZSS_L2C_ENA         0x10310015  /**< QZSS L2C (only on u-blox F9 platform products) */
+#define UBX_CFG_KEY_SIGNAL_GLO_ENA              0x10310025  /**< GLONASS enable */
+#define UBX_CFG_KEY_SIGNAL_GLO_L1_ENA           0x10310018  /**< GLONASS L1 */
+#define UBX_CFG_KEY_SIGNAL_GLO_L2_ENA           0x1031001a  /**< GLONASS L2 (only on u-blox F9 platform products) */
 
 #define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX7        (sizeof(ubx_payload_rx_nav_pvt_t) - 8)
 #define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX8        (sizeof(ubx_payload_rx_nav_pvt_t))
@@ -718,6 +767,23 @@ typedef struct {
 	uint8_t  reserved3[8];
 } ubx_payload_tx_cfg_tmode3_t;
 
+typedef struct {
+	uint8_t msgVer;           /**< Message version (expected 0x00) */
+	uint8_t numTrkChHw;       /**< Number of tracking channels available (read only) */
+	uint8_t numTrkChUse;      /**< Number of tracking channels to use (0xFF for numTrkChHw) */
+	uint8_t numConfigBlocks;  /**< Count of repeated blocks */
+
+	struct ubx_payload_tx_cgf_gnss_block_t {
+		uint8_t gnssId;     /**< GNSS ID */
+		uint8_t resTrkCh;   /**< Number of reseved (minimum) tracking channels */
+		uint8_t maxTrkCh;   /**< Maximum number or tracking channels */
+		uint8_t reserved1;
+		uint32_t flags;     /**< Bitfield flags (see UBX_TX_CFG_GNSS_FLAGS_*) */
+	};
+
+	ubx_payload_tx_cgf_gnss_block_t block[7];  /**< GPS, SBAS, Galileo, BeiDou, IMES 0-8, QZSS, GLONASS */
+} ubx_payload_tx_cfg_gnss_t;
+
 /* NAV RELPOSNED (protocol version 27+) */
 typedef struct {
 	uint8_t     version;         /**< message version (expected 0x01) */
@@ -772,6 +838,7 @@ typedef union {
 	ubx_payload_tx_cfg_tmode3_t       payload_tx_cfg_tmode3;
 	ubx_payload_tx_cfg_cfg_t          payload_tx_cfg_cfg;
 	ubx_payload_tx_cfg_valset_t       payload_tx_cfg_valset;
+	ubx_payload_tx_cfg_gnss_t         payload_tx_cfg_gnss;
 	ubx_payload_rx_nav_relposned_t    payload_rx_nav_relposned;
 } ubx_buf_t;
 
@@ -864,14 +931,16 @@ private:
 
 	/**
 	 * Send configuration values and desired message rates
+	 * @param gnssSystems Set of GNSS systems to use
 	 * @return 0 on success, <0 on error
 	 */
-	int configureDevice();
+	int configureDevice(const GNSSSystemsMask &gnssSystems);
 	/**
 	 * Send configuration values and desired message rates (for protocol version < 27)
+	 * @param gnssSystems Set of GNSS systems to use
 	 * @return 0 on success, <0 on error
 	 */
-	int configureDevicePreV27();
+	int configureDevicePreV27(const GNSSSystemsMask &gnssSystems);
 
 	/**
 	 * Add a configuration value to _buf and increase the message size msg_size as needed

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -826,7 +826,7 @@ public:
 
 	virtual ~GPSDriverUBX();
 
-	int configure(unsigned &baudrate, OutputMode output_mode) override;
+	int configure(unsigned &baudrate, const GPSConfig &config) override;
 	int receive(unsigned timeout) override;
 	int reset(GPSRestartType restart_type) override;
 


### PR DESCRIPTION
A new PX4 parameter is needed to configure the set of used GNSS systems. This PR changes the `GPSHelper::configure()` interface method used by the GPS drivers to include another parameter for the configuration (with the same data format, as the PX4 parameter).
Additionally the actual feature of setting the GNSS configuration was implemented for uBlox devices.

See https://github.com/PX4/PX4-GPSDrivers/issues/68 for details.