### PR TITLE
Enable jamming and interference monitor 

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1992,6 +1992,7 @@ GPSDriverUBX::payloadRxDone()
 
 		_gps_position->noise_per_ms		= _buf.payload_rx_mon_rf.block[0].noisePerMS;
 		_gps_position->jamming_indicator	= _buf.payload_rx_mon_rf.block[0].jamInd;
+		_gps_position->jamming_state		= _buf.payload_rx_mon_rf.block[0].flags;
 
 		ret = 1;
 		break;

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -520,6 +520,9 @@ int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
 	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPVEL, 0, cfg_valset_msg_size);
 	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPCOG, 0, cfg_valset_msg_size);
 
+	// enable jamming monitor
+	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
+
 	// measurement rate
 	// In case of F9P we use 10Hz, otherwise 5Hz (receivers such as M9N can go higher as well, but
 	// the number of used satellites will be restricted to 16. Not mentioned in datasheet)

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -309,6 +309,8 @@
 #define UBX_CFG_KEY_ODO_OUTLPVEL                0x10220003
 #define UBX_CFG_KEY_ODO_OUTLPCOG                0x10220004
 
+#define UBX_CFG_KEY_ITFM_ENABLE					0x1041000d
+
 #define UBX_CFG_KEY_RATE_MEAS                   0x30210001
 #define UBX_CFG_KEY_RATE_NAV                    0x30210002
 #define UBX_CFG_KEY_RATE_TIMEREF                0x20210003

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -309,7 +309,7 @@
 #define UBX_CFG_KEY_ODO_OUTLPVEL                0x10220003
 #define UBX_CFG_KEY_ODO_OUTLPCOG                0x10220004
 
-#define UBX_CFG_KEY_ITFM_ENABLE					0x1041000d
+#define UBX_CFG_KEY_ITFM_ENABLE                 0x1041000d
 
 #define UBX_CFG_KEY_RATE_MEAS                   0x30210001
 #define UBX_CFG_KEY_RATE_NAV                    0x30210002


### PR DESCRIPTION
title self explanatory, this should provide more insightful information about GPS jamming state.

From u-blox Integration Manual

> The field flags of the UBX-MON-RF message can be used as an indicator for both broadband andcontinuous wave (CW) jammers/interference. It is independent of the (CW only) jamming indicatordescribed in Jamming/interference indicator above.This monitor reports whether jamming has been detected or suspected by the receiver. The receivermonitors the background noise and looks for significant changes. Normally, with no interferencedetected, it will report "OK". If the receiver detects that the noise has risen above a preset threshold,the  receiver  reports  "Warning".  If  in  addition,  there  is  no  current  valid  fix,  the  receiver  reports"Critical".