### PR TITLE
sbf: fix longitude judgement bug

### DIFF
--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -427,7 +427,7 @@ GPSDriverSBF::payloadRxDone()
 
 		// Check boundaries and invalidate position
 		// We're not just checking for the do-not-use value (-2*10^10) but for any value beyond the specified max values
-		if (fabs(_buf.payload_pvt_geodetic.latitude) > M_PI_2 || fabs(_buf.payload_pvt_geodetic.longitude) > M_PI_2 ||
+		if (fabs(_buf.payload_pvt_geodetic.latitude) > M_PI_2 || fabs(_buf.payload_pvt_geodetic.longitude) > M_PI ||
 		    fabs(_buf.payload_pvt_geodetic.height) > 100000.0 || fabs(_buf.payload_pvt_geodetic.undulation) > 100000.0) {
 			_gps_position->fix_type = 0;
 		}


### PR DESCRIPTION
H @MatejFranceskin, thanks for implementing this driver, that help a lot.  
I am recently testing the septentrio's mosaic-X5, so I found this bug.
This bug will make fix_type always be 0 in the eastern hemisphere.