### PR TITLE
Adding messageId function to return what RTCM message is in the buffer.

### DIFF
--- a/src/rtcm.h
+++ b/src/rtcm.h
@@ -60,6 +60,7 @@ public:
 
 	uint8_t *message() const { return _buffer; }
 	uint16_t messageLength() const { return _pos; }
+	uint16_t messageId() const { return (_buffer[3]<<4)|(_buffer[4]>>4); }
 
 private:
 	uint8_t			*_buffer{nullptr};

--- a/src/rtcm.h
+++ b/src/rtcm.h
@@ -60,7 +60,7 @@ public:
 
 	uint8_t *message() const { return _buffer; }
 	uint16_t messageLength() const { return _pos; }
-	uint16_t messageId() const { return (_buffer[3]<<4)|(_buffer[4]>>4); }
+	uint16_t messageId() const { return (_buffer[3] << 4) | (_buffer[4] >> 4); }
 
 private:
 	uint8_t			*_buffer{nullptr};


### PR DESCRIPTION
Fairly simple function to pull the RTCM message id out of the buffer. 
Useful for message filtering.