### PR TITLE
Remove UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X to fix M9N functionality

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -644,7 +644,6 @@ int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_RTCM3X, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_UBX, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X, 0, cfg_valset_msg_size);
 
 		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
 			return -1;

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -645,6 +645,10 @@ int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_UBX, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_NMEA, 0, cfg_valset_msg_size);
 
+		if (_board == Board::u_blox9_F9P) {
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+		}
+
 		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
 			return -1;
 		}


### PR DESCRIPTION
This PR removes the UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X message to fix U-blox M9N failing to start. Tested on a Pixhawk 4 with a M8N and M9N GPS. Also tested on an ARK CAN GPS with a M9N.