### PR TITLE
Added code to support u-blox MAX-M10S GPS module.

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -45,77 +45,94 @@
  * @author Hannes Delago
  *   (rework, add ubx7+ compatibility)
  *
- * @see https://www.u-blox.com/sites/default/files/products/documents/u-blox6-GPS-GLONASS-QZSS-V14_ReceiverDescrProtSpec_%28GPS.G6-SW-12013%29_Public.pdf
+ * @author Ilya Sopkin <ivsopkin@outlook.com>
+ *	 (added beta version of u-blox MAX-M10S gps module)
+ * 
+ *
+ * @see https://www2.u-blox.com/images/downloads/Product_Docs/u-blox6-GPS-GLONASS-QZSS-V14_ReceiverDescriptionProtocolSpec_Public_(GPS.G6-SW-12013).pdf
  * @see https://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29_Public.pdf
- * @see https://www.u-blox.com/sites/default/files/ZED-F9P_InterfaceDescription_%28UBX-18010854%29.pdf
+ * @see https://www.u-blox.com/sites/default/files/u-blox_ZED-F9P_InterfaceDescription_%28UBX-18010854%29.pdf
+ * @see https://www.u-blox.com/en/ubx-viewer/view/u-blox-M10-SPG-5.00_InterfaceDescription_UBX-20053845?url=https%3A%2F%2Fwww.u-blox.com%2Fsites%2Fdefault%2Ffiles%2Fu-blox%2520M10-SPG-5.00_InterfaceDescription_UBX-20053845.pdf
  */
 
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
 #include <string.h>
+#include <ctime>
 
-#include "rtcm.h"
 #include "ubx.h"
+#include "rtcm.h"
 
-#define MIN(X,Y)              ((X) < (Y) ? (X) : (Y))
-#define SWAP16(X)             ((((X) >>  8) & 0x00ff) | (((X) << 8) & 0xff00))
+#define UBX_CONFIG_TIMEOUT	1000		// ms, timeout for waiting ACK
+#define UBX_PACKET_TIMEOUT	2		// ms, if now data during this delay assume that full update received
+#define DISABLE_MSG_INTERVAL	1000000		// us, try to disable message with this interval
+
+#define MIN(X,Y)	((X) < (Y) ? (X) : (Y))
+#define SWAP16(X)	((((X) >>  8) & 0x00ff) | (((X) << 8) & 0xff00))
+
+#define FNV1_32_INIT	((uint32_t)0x811c9dc5)	// init value for FNV1 hash algorithm
+#define FNV1_32_PRIME	((uint32_t)0x01000193)	// magic prime for FNV1 hash algorithm
+
 
 /**** Trace macros, disable for production builds */
-#define UBX_TRACE_PARSER(...) {/*GPS_INFO(__VA_ARGS__);*/}    // decoding progress in parse_char()
-#define UBX_TRACE_RXMSG(...)  {/*GPS_INFO(__VA_ARGS__);*/}    // Rx msgs in payload_rx_done()
-#define UBX_TRACE_SVINFO(...) {/*GPS_INFO(__VA_ARGS__);*/}    // NAV-SVINFO processing (debug use only, will cause rx buffer overflows)
+#define UBX_TRACE_PARSER(...)	{/*GPS_INFO(__VA_ARGS__);*/}	/* decoding progress in parse_char() */
+#define UBX_TRACE_RXMSG(...)		{/*GPS_INFO(__VA_ARGS__);*/}	/* Rx msgs in payload_rx_done() */
+#define UBX_TRACE_SVINFO(...)	{/*GPS_INFO(__VA_ARGS__);*/}	/* NAV-SVINFO processing (debug use only, will cause rx buffer overflows) */
 
 /**** Warning macros, disable to save memory */
-#define UBX_WARN(...)         {GPS_WARN(__VA_ARGS__);}
-#define UBX_DEBUG(...)        {/*GPS_WARN(__VA_ARGS__);*/}
+#define UBX_WARN(...)		{GPS_WARN(__VA_ARGS__);}
+#define UBX_DEBUG(...)		{/*GPS_WARN(__VA_ARGS__);*/}
 
 GPSDriverUBX::GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void *callback_user,
-			   sensor_gps_s *gps_position, satellite_info_s *satellite_info, uint8_t dynamic_model,
-			   float heading_offset, UBXMode mode) :
-	GPSBaseStationSupport(callback, callback_user),
-	_interface(gpsInterface),
-	_gps_position(gps_position),
-	_satellite_info(satellite_info),
-	_dyn_model(dynamic_model),
-	_mode(mode),
-	_heading_offset(heading_offset)
+			   struct vehicle_gps_position_s *gps_position,
+			   struct satellite_info_s *satellite_info,
+			   uint8_t dynamic_model)
+	: GPSBaseStationSupport(callback, callback_user)
+	, _gps_position(gps_position)
+	, _satellite_info(satellite_info)
+	, _interface(gpsInterface)
+	, _dyn_model(dynamic_model)
 {
 	decodeInit();
 }
 
 GPSDriverUBX::~GPSDriverUBX()
 {
-	delete _rtcm_parsing;
+	if (_rtcm_parsing) {
+		delete (_rtcm_parsing);
+	}
 }
 
 int
-GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
+GPSDriverUBX::configure(unsigned &baudrate, OutputMode output_mode)
 {
 	_configured = false;
-	_output_mode = config.output_mode;
+	_output_mode = output_mode;
 
-	ubx_payload_tx_cfg_prt_t cfg_prt[2];
-
-	uint16_t out_proto_mask = _output_mode == OutputMode::GPS ?
-				  UBX_TX_CFG_PRT_PROTO_UBX :
-				  (UBX_TX_CFG_PRT_PROTO_UBX | UBX_TX_CFG_PRT_PROTO_RTCM);
-
-	uint16_t in_proto_mask = (_output_mode == OutputMode::GPS || _output_mode == OutputMode::GPSAndRTCM) ?
-				 (UBX_TX_CFG_PRT_PROTO_UBX | UBX_TX_CFG_PRT_PROTO_RTCM) :
-				 UBX_TX_CFG_PRT_PROTO_UBX;
-
+	//ubx_payload_tx_cfg_prt_t cfg_prt[2];
+	// uint16_t out_proto_mask = output_mode == OutputMode::GPS ?
+	// 			  UBX_TX_CFG_PRT_OUTPROTOMASK_GPS :
+	// 			  UBX_TX_CFG_PRT_OUTPROTOMASK_RTCM;
+	// uint16_t in_proto_mask = output_mode == OutputMode::GPS ?
+	// 			 UBX_TX_CFG_PRT_INPROTOMASK_GPS :
+	// 			 UBX_TX_CFG_PRT_INPROTOMASK_RTCM;
 	const bool auto_baudrate = baudrate == 0;
 
-	if (_interface == Interface::UART) {
-
+	if (_interface == Interface::UART)
+	{
 		/* try different baudrates */
 		const unsigned baudrates[] = {38400, 57600, 9600, 115200, 230400};
 
 		unsigned baud_i;
 		unsigned desired_baudrate = auto_baudrate ? UBX_BAUDRATE_M8_AND_NEWER : baudrate;
 
-		for (baud_i = 0; baud_i < sizeof(baudrates) / sizeof(baudrates[0]); baud_i++) {
+		for (baud_i = 0; baud_i < sizeof(baudrates) / sizeof(baudrates[0]); baud_i++)
+		{
 			unsigned test_baudrate = baudrates[baud_i];
 
-			if (!auto_baudrate && baudrate != test_baudrate) {
+			if (!auto_baudrate && baudrate != test_baudrate)
+			{
 				continue; // skip to next baudrate
 			}
 
@@ -125,172 +142,209 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 
 			/* flush input and wait for at least 20 ms silence */
 			decodeInit();
-			receive(20);
+			receive(100);
 			decodeInit();
+
+			bool send_msg_flag = false;
+			bool cfg_valset_success = false;
 
 			// try CFG-VALSET: if we get an ACK we know we can use protocol version 27+
 			int cfg_valset_msg_size = initCfgValset();
+
 			// UART1
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_STOPBITS, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_DATABITS, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_PARITY, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, _output_mode == OutputMode::RTCM ? 0 : 1,
-					   cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
 
-			if (_output_mode != OutputMode::GPS) {
-				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
-			}
+			send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
 
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA, 0, cfg_valset_msg_size);
-			// TODO: are we ever connected to UART2?
+			if (send_msg_flag)
+			{
+				cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
 
-			// USB
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_RTCM3X, _output_mode == OutputMode::RTCM ? 0 : 1,
-					   cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_NMEA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_UBX, 1, cfg_valset_msg_size);
-
-			if (_output_mode != OutputMode::GPS) {
-				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X, 1, cfg_valset_msg_size);
-			}
-
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_NMEA, 0, cfg_valset_msg_size);
-
-			bool cfg_valset_success = false;
-
-			if (sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-
-				if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) == 0) {
-					cfg_valset_success = true;
+				if(!cfg_valset_success)
+				{
+					UBX_DEBUG("UBX_CFG_KEY_CFG_UART1_STOPBITS ACK ERROR!");
+					//return -1;
+				}
+				else
+				{
+					/* at this point we have correct baudrate on both ends */
+					baudrate = test_baudrate;
 				}
 			}
+			else
+			{
+				UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+			}
 
-			if (cfg_valset_success) {
-				_proto_ver_27_or_higher = true;
-				// Now we only have to change the baudrate
+			if(cfg_valset_success)
+			{
 				cfg_valset_msg_size = initCfgValset();
-				cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART1_BAUDRATE, desired_baudrate, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_DATABITS, 0, cfg_valset_msg_size);
 
-				if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-					continue;
+				send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+				if (send_msg_flag)
+				{
+					cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+					if(!cfg_valset_success)
+					{
+						UBX_DEBUG("UBX_CFG_KEY_CFG_UART1_DATABITS ACK ERROR!");
+					}
+				}
+				else
+				{
+					UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
 				}
 
-				/* no ACK is expected here, but read the buffer anyway in case we actually get an ACK */
-				waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
+				cfg_valset_msg_size = initCfgValset();
+				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_PARITY, 0, cfg_valset_msg_size);
 
-			} else {
-				_proto_ver_27_or_higher = false;
+				send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
 
-				UBX_DEBUG("trying old protocol");
+				if (send_msg_flag)
+				{
+					cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
 
-				/* Send a CFG-PRT message to set the UBX protocol for in and out
-				 * and leave the baudrate as it is, we just want an ACK-ACK for this */
-				memset(cfg_prt, 0, 2 * sizeof(ubx_payload_tx_cfg_prt_t));
-				cfg_prt[0].portID		= UBX_TX_CFG_PRT_PORTID;
-				cfg_prt[0].mode		= UBX_TX_CFG_PRT_MODE;
-				cfg_prt[0].baudRate	= test_baudrate;
-				cfg_prt[0].inProtoMask	= in_proto_mask;
-				cfg_prt[0].outProtoMask	= out_proto_mask;
-				cfg_prt[1].portID		= UBX_TX_CFG_PRT_PORTID_USB;
-				cfg_prt[1].mode		= UBX_TX_CFG_PRT_MODE;
-				cfg_prt[1].baudRate	= test_baudrate;
-				cfg_prt[1].inProtoMask	= in_proto_mask;
-				cfg_prt[1].outProtoMask	= out_proto_mask;
-
-				if (!sendMessage(UBX_MSG_CFG_PRT, (uint8_t *)cfg_prt, 2 * sizeof(ubx_payload_tx_cfg_prt_t))) {
-					continue;
+					if(!cfg_valset_success)
+					{
+						UBX_DEBUG("UBX_CFG_KEY_CFG_UART1_PARITY ACK ERROR!");
+					}
+				}
+				else
+				{
+					UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
 				}
 
-				if (waitForAck(UBX_MSG_CFG_PRT, UBX_CONFIG_TIMEOUT, false) < 0) {
-					/* try next baudrate */
-					continue;
+				cfg_valset_msg_size = initCfgValset();
+				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1, cfg_valset_msg_size);
+
+				send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+				if (send_msg_flag)
+				{
+					cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+					if(!cfg_valset_success)
+					{
+						UBX_DEBUG("UBX_CFG_KEY_CFG_UART1INPROT_UBX ACK ERROR!");
+					}
+				}
+				else
+				{
+					UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
 				}
 
-				if (auto_baudrate) {
-					desired_baudrate = UBX_TX_CFG_PRT_BAUDRATE;
+				cfg_valset_msg_size = initCfgValset();
+				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0, cfg_valset_msg_size);
+
+				send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+				if (send_msg_flag)
+				{
+					cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+					if(!cfg_valset_success)
+					{
+						UBX_DEBUG("UBX_CFG_KEY_CFG_UART1INPROT_NMEA ACK ERROR!");
+					}
+				}
+				else
+				{
+					UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
 				}
 
-				/* Send a CFG-PRT message again, this time change the baudrate */
-				cfg_prt[0].baudRate	= desired_baudrate;
-				cfg_prt[1].baudRate	= desired_baudrate;
+				cfg_valset_msg_size = initCfgValset();
+				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
 
-				if (!sendMessage(UBX_MSG_CFG_PRT, (uint8_t *)cfg_prt, 2 * sizeof(ubx_payload_tx_cfg_prt_t))) {
-					continue;
+				send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+				if (send_msg_flag)
+				{
+					cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+					if(!cfg_valset_success)
+					{
+						UBX_DEBUG("UBX_CFG_KEY_CFG_UART1OUTPROT_UBX ACK ERROR!");
+					}
+				}
+				else
+				{
+					UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
 				}
 
-				/* no ACK is expected here, but read the buffer anyway in case we actually get an ACK */
-				waitForAck(UBX_MSG_CFG_PRT, UBX_CONFIG_TIMEOUT, false);
+				cfg_valset_msg_size = initCfgValset();
+				cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA, 0, cfg_valset_msg_size);
+
+				send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+				if (send_msg_flag)
+				{
+					cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+					if(!cfg_valset_success)
+					{
+						UBX_DEBUG("UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA ACK ERROR!");
+					}
+				}
+				else
+				{
+					UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+				}
+
+				if(cfg_valset_success)
+				{
+					UBX_DEBUG("Initial configure complete [OK]");
+
+					_proto_ver_27_or_higher = true;
+
+					if(baudrate != desired_baudrate)
+					{
+						// Now we only have to change the baudrate if it need
+						cfg_valset_msg_size = initCfgValset();
+						baudrate = desired_baudrate;
+						cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART1_BAUDRATE, baudrate, cfg_valset_msg_size);
+
+						if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size))
+						{
+							continue;
+						}
+
+						/* no ACK is expected here, but read the buffer anyway in case we actually get an ACK */
+						waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
+					}
+
+					break;
+				}
 			}
 
-			if (desired_baudrate != test_baudrate) {
-				setBaudrate(desired_baudrate);
+			// if (desired_baudrate != test_baudrate) {
+			// 	setBaudrate(desired_baudrate);
 
-				decodeInit();
-				receive(20);
-				decodeInit();
-			}
+			// 	decodeInit();
+			// 	receive(100);
+			// 	decodeInit();
+			// }
 
 			/* at this point we have correct baudrate on both ends */
-			baudrate = desired_baudrate;
-			break;
+			//baudrate = desired_baudrate;
+			//break;
 		}
 
 		if (baud_i >= sizeof(baudrates) / sizeof(baudrates[0])) {
 			return -1;	// connection and/or baudrate detection failed
 		}
-
-	} else if (_interface == Interface::SPI) {
-
-		// try CFG-VALSET: if we get an ACK we know we can use protocol version 27+
-		int cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_ENABLED, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_MAXFF, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X, _output_mode == OutputMode::RTCM ? 0 : 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X, _output_mode == OutputMode::GPS ? 0 : 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA, 0, cfg_valset_msg_size);
-
-		bool cfg_valset_success = false;
-
-		if (sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-
-			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) == 0) {
-				cfg_valset_success = true;
-			}
-		}
-
-		if (cfg_valset_success) {
-			_proto_ver_27_or_higher = true;
-
-		} else {
-			_proto_ver_27_or_higher = false;
-			memset(cfg_prt, 0, sizeof(ubx_payload_tx_cfg_prt_t));
-			cfg_prt[0].portID		= UBX_TX_CFG_PRT_PORTID_SPI;
-			cfg_prt[0].mode			= UBX_TX_CFG_PRT_MODE_SPI;
-			cfg_prt[0].inProtoMask	= in_proto_mask;
-			cfg_prt[0].outProtoMask	= out_proto_mask;
-
-			if (!sendMessage(UBX_MSG_CFG_PRT, (uint8_t *)cfg_prt, sizeof(ubx_payload_tx_cfg_prt_t))) {
-				return -1;
-			}
-
-			waitForAck(UBX_MSG_CFG_PRT, UBX_CONFIG_TIMEOUT, false);
-		}
-
-	} else {
+	}
+	else
+	{
 		return -1;
 	}
 
-	UBX_DEBUG("Protocol version 27+: %i", static_cast<int>(_proto_ver_27_or_higher));
+	UBX_DEBUG("Protocol version 27+: %i", (int)_proto_ver_27_or_higher);
 
 	/* Request module version information by sending an empty MON-VER message */
 	if (!sendMessage(UBX_MSG_MON_VER, nullptr, 0)) {
+		UBX_DEBUG("Sending an empty MON-VER message ERROR!");
 		return -1;
 	}
 
@@ -298,62 +352,59 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 	 * Note: we won't actually get an ACK-ACK, but UBX_MSG_MON_VER will also set the ack state.
 	 */
 	if (waitForAck(UBX_MSG_MON_VER, UBX_CONFIG_TIMEOUT, true) < 0) {
+		UBX_DEBUG("UBX_MSG_MON_VER ACK-ACK ERROR!");
 		return -1;
 	}
 
 
 	/* Now that we know the board, update the baudrate on M8 boards (on F9+ we already used the
 	 * higher baudrate with CFG-VALSET) */
-	if (_interface == Interface::UART && auto_baudrate && _board == Board::u_blox8) {
+	// if (_interface == Interface::UART && auto_baudrate && _board == Board::u_blox8) {
 
-		cfg_prt[0].baudRate	= UBX_BAUDRATE_M8_AND_NEWER;
-		cfg_prt[1].baudRate	= UBX_BAUDRATE_M8_AND_NEWER;
+	// 	cfg_prt[0].baudRate	= UBX_BAUDRATE_M8_AND_NEWER;
+	// 	cfg_prt[1].baudRate	= UBX_BAUDRATE_M8_AND_NEWER;
 
-		if (sendMessage(UBX_MSG_CFG_PRT, (uint8_t *)cfg_prt, 2 * sizeof(ubx_payload_tx_cfg_prt_t))) {
-			/* no ACK is expected here, but read the buffer anyway in case we actually get an ACK */
-			waitForAck(UBX_MSG_CFG_PRT, UBX_CONFIG_TIMEOUT, false);
+	// 	if (sendMessage(UBX_MSG_CFG_PRT, (uint8_t *)cfg_prt, 2 * sizeof(ubx_payload_tx_cfg_prt_t))) {
+	// 		/* no ACK is expected here, but read the buffer anyway in case we actually get an ACK */
+	// 		//waitForAck(UBX_MSG_CFG_PRT, UBX_CONFIG_TIMEOUT, false);
 
-			setBaudrate(UBX_BAUDRATE_M8_AND_NEWER);
-			baudrate = UBX_BAUDRATE_M8_AND_NEWER;
-		}
-	}
+	// 		setBaudrate(UBX_BAUDRATE_M8_AND_NEWER);
+	// 		baudrate = UBX_BAUDRATE_M8_AND_NEWER;
+	// 	}
+	// }
 
 
-	if (_output_mode == OutputMode::RTCM) {
+	if (output_mode != OutputMode::GPS) {
 		// RTCM mode force stationary dynamic model
 		_dyn_model = 2;
 	}
 
-	int ret;
+	int ret = -1;
 
 	if (_proto_ver_27_or_higher) {
-		ret = configureDevice(config.gnss_systems);
+		ret = configureDevice();
 
-	} else {
-		ret = configureDevicePreV27(config.gnss_systems);
 	}
+	/*else {
+		ret = configureDevicePreV27();
+	}*/
 
 	if (ret != 0) {
 		return ret;
 	}
 
-	if (_output_mode == OutputMode::RTCM) {
+	/*if (output_mode == OutputMode::RTCM) {
 		if (restartSurveyIn() < 0) {
 			return -1;
 		}
-
-	} else if (_output_mode == OutputMode::GPSAndRTCM) {
-		if (activateRTCMOutput(false) < 0) {
-			return -1;
-		}
-	}
+	}*/
 
 	_configured = true;
 	return 0;
 }
 
 
-int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
+int GPSDriverUBX::configureDevicePreV27()
 {
 	/* Send a CFG-RATE message to define update rate */
 	memset(&_buf.payload_tx_cfg_rate, 0, sizeof(_buf.payload_tx_cfg_rate));
@@ -381,80 +432,6 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 
 	if (waitForAck(UBX_MSG_CFG_NAV5, UBX_CONFIG_TIMEOUT, true) < 0) {
 		return -1;
-	}
-
-	/* configure active GNSS systems (number of channels and used signals taken from U-Center default) */
-	if (static_cast<int32_t>(gnssSystems) != 0) {
-		memset(&_buf.payload_tx_cfg_gnss, 0, sizeof(_buf.payload_tx_cfg_gnss));
-		_buf.payload_tx_cfg_gnss.msgVer = 0x00;
-		_buf.payload_tx_cfg_gnss.numTrkChHw = 0x00;  // read only
-		_buf.payload_tx_cfg_gnss.numTrkChUse = 0xFF;  // use max number of HW channels
-		_buf.payload_tx_cfg_gnss.numConfigBlocks = 7;  // always configure all systems
-
-		// GPS and QZSS should always be enabled and disabled together, according to uBlox
-		_buf.payload_tx_cfg_gnss.block[0].gnssId = UBX_TX_CFG_GNSS_GNSSID_GPS;
-		_buf.payload_tx_cfg_gnss.block[1].gnssId = UBX_TX_CFG_GNSS_GNSSID_QZSS;
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_GPS) {
-			UBX_DEBUG("GNSS Systems: Use GPS + QZSS");
-			_buf.payload_tx_cfg_gnss.block[0].resTrkCh = 8;
-			_buf.payload_tx_cfg_gnss.block[0].maxTrkCh = 16;
-			_buf.payload_tx_cfg_gnss.block[0].flags = UBX_TX_CFG_GNSS_FLAGS_GPS_L1CA | UBX_TX_CFG_GNSS_FLAGS_ENABLE;
-			_buf.payload_tx_cfg_gnss.block[1].resTrkCh = 0;
-			_buf.payload_tx_cfg_gnss.block[1].maxTrkCh = 3;
-			_buf.payload_tx_cfg_gnss.block[1].flags = UBX_TX_CFG_GNSS_FLAGS_QZSS_L1CA | UBX_TX_CFG_GNSS_FLAGS_ENABLE;
-		}
-
-		_buf.payload_tx_cfg_gnss.block[2].gnssId = UBX_TX_CFG_GNSS_GNSSID_SBAS;
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_SBAS) {
-			UBX_DEBUG("GNSS Systems: Use SBAS");
-			_buf.payload_tx_cfg_gnss.block[2].resTrkCh = 1;
-			_buf.payload_tx_cfg_gnss.block[2].maxTrkCh = 3;
-			_buf.payload_tx_cfg_gnss.block[2].flags = UBX_TX_CFG_GNSS_FLAGS_SBAS_L1CA | UBX_TX_CFG_GNSS_FLAGS_ENABLE;
-		}
-
-		_buf.payload_tx_cfg_gnss.block[3].gnssId = UBX_TX_CFG_GNSS_GNSSID_GALILEO;
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_GALILEO) {
-			UBX_DEBUG("GNSS Systems: Use Galileo");
-			_buf.payload_tx_cfg_gnss.block[3].resTrkCh = 4;
-			_buf.payload_tx_cfg_gnss.block[3].maxTrkCh = 8;
-			_buf.payload_tx_cfg_gnss.block[3].flags = UBX_TX_CFG_GNSS_FLAGS_GALILEO_E1 | UBX_TX_CFG_GNSS_FLAGS_ENABLE;
-		}
-
-		_buf.payload_tx_cfg_gnss.block[4].gnssId = UBX_TX_CFG_GNSS_GNSSID_BEIDOU;
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_BEIDOU) {
-			UBX_DEBUG("GNSS Systems: Use BeiDou");
-			_buf.payload_tx_cfg_gnss.block[4].resTrkCh = 8;
-			_buf.payload_tx_cfg_gnss.block[4].maxTrkCh = 16;
-			_buf.payload_tx_cfg_gnss.block[4].flags = UBX_TX_CFG_GNSS_FLAGS_BEIDOU_B1I | UBX_TX_CFG_GNSS_FLAGS_ENABLE;
-		}
-
-		_buf.payload_tx_cfg_gnss.block[5].gnssId = UBX_TX_CFG_GNSS_GNSSID_GLONASS;
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_GLONASS) {
-			UBX_DEBUG("GNSS Systems: Use GLONASS");
-			_buf.payload_tx_cfg_gnss.block[5].resTrkCh = 8;
-			_buf.payload_tx_cfg_gnss.block[5].maxTrkCh = 14;
-			_buf.payload_tx_cfg_gnss.block[5].flags = UBX_TX_CFG_GNSS_FLAGS_GLONASS_L1 | UBX_TX_CFG_GNSS_FLAGS_ENABLE;
-		}
-
-		// IMES always disabled
-		_buf.payload_tx_cfg_gnss.block[6].gnssId = UBX_TX_CFG_GNSS_GNSSID_IMES;
-		_buf.payload_tx_cfg_gnss.block[6].flags = 0;
-
-		// send message
-		if (!sendMessage(UBX_MSG_CFG_GNSS, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_gnss))) {
-			GPS_ERR("UBX CFG-GNSS message send failed");
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_GNSS, UBX_CONFIG_TIMEOUT, true) < 0) {
-			GPS_ERR("UBX CFG-GNSS message ACK failed");
-			return -1;
-		}
 	}
 
 	/* configure message rates */
@@ -508,212 +485,619 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 	return 0;
 }
 
-int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
+int GPSDriverUBX::configureDevice()
 {
+	bool send_msg_flag = false;
+	bool cfg_valset_success = false;
+
 	/* set configuration parameters */
 	int cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_FIXMODE, 3 /* Auto 2d/3d */, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_NAVSPG_FIXMODE ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+ 	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_UTCSTANDARD, 3 /* USNO (U.S. Naval Observatory derived from GPS) */,
 			   cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_NAVSPG_UTCSTANDARD ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_DYNMODEL, _dyn_model, cfg_valset_msg_size);
 
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_NAVSPG_DYNMODEL ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
 	// disable odometer & filtering
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_ODO_USE_ODO ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_COG, 0, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_ODO_USE_COG ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPVEL, 0, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_ODO_OUTLPVEL ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPCOG, 0, cfg_valset_msg_size);
 
-	// enable jamming monitor
-	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_ODO_OUTLPCOG ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
 
 	// measurement rate
-	// In case of F9P we use 10Hz, otherwise 8Hz (receivers such as M9N can go higher as well, but
+	// In case of F9P we use 10Hz, otherwise 5Hz (receivers such as M9N can go higher as well, but
 	// the number of used satellites will be restricted to 16. Not mentioned in datasheet)
-	const int rate_meas = (_board == Board::u_blox9_F9P) ? 100 : 125;
+	int rate_meas = 0;
+
+	if((_board == Board::u_blox9_F9P) || (_board == Board::u_blox10))
+	{
+		rate_meas = 100;
+	}
+	else
+	{
+		rate_meas = 200;
+	}
+
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, rate_meas, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_RATE_MEAS ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_NAV, 1, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_RATE_NAV ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_RATE_TIMEREF, 0, cfg_valset_msg_size);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-		return -1;
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_RATE_TIMEREF ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
 	}
 
-	if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-		return -1;
-	}
+
+	// if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	// 	return -1;
+	// }
+
+	// if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+	// 	return -1;
+	// }
 
 	// RTK (optional, as only RTK devices like F9P support it)
-	cfg_valset_msg_size = initCfgValset();
-	cfgValset<uint8_t>(UBX_CFG_KEY_NAVHPG_DGNSSMODE, 3 /* RTK Fixed */, cfg_valset_msg_size);
+	// cfg_valset_msg_size = initCfgValset();
+	// cfgValset<uint8_t>(UBX_CFG_KEY_NAVHPG_DGNSSMODE, 3 /* RTK Fixed */, cfg_valset_msg_size);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-		return -1;
-	}
+	// send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
 
-	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
+	// if (send_msg_flag)
+	// {
+	// 	cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
 
-	// configure active GNSS systems (leave signal bands as is)
-	if (static_cast<int32_t>(gnssSystems) != 0) {
-		cfg_valset_msg_size = initCfgValset();
+	// 	if(!cfg_valset_success)
+	// 	{
+	// 		UBX_DEBUG("UBX_CFG_KEY_NAVHPG_DGNSSMODE ACK ERROR!");
+	// 	}
+	// }
+	// else
+	// {
+	// 	UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	// }
 
-		// GPS and QZSS should always be enabled and disabled together, according to uBlox
-		if (gnssSystems & GNSSSystemsMask::ENABLE_GPS) {
-			UBX_DEBUG("GNSS Systems: Use GPS + QZSS");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_ENA, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, 1, cfg_valset_msg_size);
+	// if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	// 	return -1;
+	// }
 
-		} else {
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_ENA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, 0, cfg_valset_msg_size);
-		}
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_GALILEO) {
-			UBX_DEBUG("GNSS Systems: Use Galileo");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_ENA, 1, cfg_valset_msg_size);
-
-		} else {
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_ENA, 0, cfg_valset_msg_size);
-		}
-
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_BEIDOU) {
-			UBX_DEBUG("GNSS Systems: Use BeiDou");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_ENA, 1, cfg_valset_msg_size);
-
-		} else {
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_ENA, 0, cfg_valset_msg_size);
-		}
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_GLONASS) {
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_ENA, 1, cfg_valset_msg_size);
-
-		} else {
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_ENA, 0, cfg_valset_msg_size);
-		}
-
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-			GPS_ERR("UBX GNSS config send failed");
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-			return -1;
-		}
-
-		// send SBAS config separately, because it seems to be buggy (with u-center, too)
-		cfg_valset_msg_size = initCfgValset();
-
-		if (gnssSystems & GNSSSystemsMask::ENABLE_SBAS) {
-			UBX_DEBUG("GNSS Systems: Use SBAS");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_ENA, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_L1CA_ENA, 1, cfg_valset_msg_size);
-
-		} else {
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_ENA, 0, cfg_valset_msg_size);
-		}
-
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-			return -1;
-		}
-
-		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true);
-	}
+	// waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 
 	// Configure message rates
 	// Send a new CFG-VALSET message to make sure it does not get too large
 	cfg_valset_msg_size = initCfgValset();
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_UART1, 1, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_UART1 ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
 	_use_nav_pvt = true;
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, (_satellite_info != nullptr) ? 10 : 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1, cfg_valset_msg_size);
+	cfg_valset_msg_size = initCfgValset();
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_UART1, 1, cfg_valset_msg_size);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-		return -1;
-	}
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
 
-	if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-		return -1;
-	}
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
 
-	if (_interface == Interface::UART) {
-		// Disable GPS protocols at I2C
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_RTCM3X, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_NMEA, 0, cfg_valset_msg_size);
-
-		if (_board == Board::u_blox9_F9P) {
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-		}
-
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-			return -1;
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_UART1 ACK ERROR!");
 		}
 	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
 
-	int uart2_baudrate = 230400;
+	cfg_valset_msg_size = initCfgValset();
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_UART1, (_satellite_info != nullptr) ? 10 : 0, cfg_valset_msg_size);
 
-	if (_mode == UBXMode::RoverWithMovingBase) {
-		UBX_DEBUG("Configuring UART2 for rover");
-		cfg_valset_msg_size = initCfgValset();
-		// heading output @3Hz
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C, 3, cfg_valset_msg_size);
-		// enable RTCM input on uart2 + set baudrate
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-			return -1;
-		}
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
 
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-			return -1;
-		}
-
-	} else if (_mode == UBXMode::MovingBase) {
-		UBX_DEBUG("Configuring UART2 for moving base");
-		// enable RTCM output on uart2 + set baudrate
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
-
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_1_UART2, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART2, 1, cfg_valset_msg_size);
-
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-			return -1;
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_UART1 ACK ERROR!");
 		}
 	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_UART1, 1, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_MSGOUT_UBX_MON_RF_UART1 ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_KEY_HW_RF_LNA_MODE, 1, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_HW_RF_LNA_MODE ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ANTSETTING, 1, cfg_valset_msg_size);
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_KEY_ITFM_ANTSETTING ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_GPS_ENA, 1, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_GPS_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_GPS_L1CA_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_GPS_L1CA_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_SBAS_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_SBAS_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_SBAS_L1CA_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_SBAS_L1CA_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_GAL_ENA, 1, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_GAL_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_GAL_El_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_GAL_El_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_BDS_ENA, 1, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_BDS_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_BDS_B1_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_BDS_B1_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_QZSS_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_QZSS_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_QZSS_L1CA_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_QZSS_L1CA_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_GLO_ENA, 1, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_GLO_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_SIGNAL_GLO_L1_ENA, 0, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_GLO_L1_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+
+	send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	if (send_msg_flag)
+	{
+		cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+		if(!cfg_valset_success)
+		{
+			UBX_DEBUG("UBX_CFG_SIGNAL_GLO_L1_ENA ACK ERROR!");
+		}
+	}
+	else
+	{
+		UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	}
+
+	// cfg_valset_msg_size = initCfgValset();
+	// cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_VELNED_UART1, 1, cfg_valset_msg_size);
+
+	// send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+
+	// if (send_msg_flag)
+	// {
+	// 	cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
+
+	// 	if(!cfg_valset_success)
+	// 	{
+	// 		UBX_DEBUG("UBX_CFG_KEY_MSGOUT_UBX_NAV_VELNED_UART1 ACK ERROR!");
+	// 	}
+	// }
+	// else
+	// {
+	// 	UBX_DEBUG("sendMessage UBX_MSG_CFG_VALSET ERROR!");
+	// }
+
+	// if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	// 	return -1;
+
+	// }
+
+	// if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+	// 	return -1;
+	// }
 
 	return 0;
 }
@@ -723,6 +1107,24 @@ int GPSDriverUBX::initCfgValset()
 	memset(&_buf.payload_tx_cfg_valset, 0, sizeof(_buf.payload_tx_cfg_valset));
 	_buf.payload_tx_cfg_valset.layers = UBX_CFG_LAYER_RAM;
 	return sizeof(_buf.payload_tx_cfg_valset) - sizeof(_buf.payload_tx_cfg_valset.cfgData);
+}
+
+bool GPSDriverUBX::ackWaiting(const uint16_t msg)
+{
+	bool ack_flag = true;
+
+	ack_flag = (bool)waitForAck(msg, UBX_CONFIG_TIMEOUT, true);
+
+	if (ack_flag == false)
+	{
+		ack_flag = true;
+
+		return true;
+	}
+	else
+	{
+		return false;
+	}
 }
 
 template<typename T>
@@ -744,18 +1146,15 @@ bool GPSDriverUBX::cfgValset(uint32_t key_id, T value, int &msg_size)
 
 bool GPSDriverUBX::cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size)
 {
-	if (_interface == Interface::SPI) {
-		if (!cfgValset<uint8_t>(key_id + 4, value, msg_size)) {
-			return false;
-		}
+	// if (_interface == Interface::SPI) {
+	// 	if (!cfgValset<uint8_t>(key_id + 4, value, msg_size)) {
+	// 		return false;
+	// 	}
 
-	} else {
-		// enable on UART1 & USB (TODO: should we enable UART2 too? -> better would be to detect the port)
-		if (!cfgValset<uint8_t>(key_id + 1, value, msg_size)) {
-			return false;
-		}
-
-		if (!cfgValset<uint8_t>(key_id + 3, value, msg_size)) {
+	// }
+	if (_interface == Interface::UART)
+	{
+		if (!cfgValset<uint8_t>(key_id, value, msg_size)) {
 			return false;
 		}
 	}
@@ -836,7 +1235,7 @@ int GPSDriverUBX::restartSurveyInPreV27()
 		}
 
 		// directly enable RTCM3 output
-		return activateRTCMOutput(true);
+		return activateRTCMOutput();
 	}
 
 	return 0;
@@ -908,7 +1307,7 @@ int GPSDriverUBX::restartSurveyIn()
 		}
 
 		// directly enable RTCM3 output
-		return activateRTCMOutput(true);
+		return activateRTCMOutput();
 
 	}
 
@@ -1085,9 +1484,9 @@ GPSDriverUBX::parseChar(const uint8_t b)
 			ret = payloadRxAddNavSat(b);	// add a NAV-SAT payload byte
 			break;
 
-		case UBX_MSG_NAV_SVINFO:
-			ret = payloadRxAddNavSvinfo(b);	// add a NAV-SVINFO payload byte
-			break;
+		// case UBX_MSG_NAV_SVINFO:
+		// 	ret = payloadRxAddNavSvinfo(b);	// add a NAV-SVINFO payload byte
+		// 	break;
 
 		case UBX_MSG_MON_VER:
 			ret = payloadRxAddMonVer(b);	// add a MON-VER payload byte
@@ -1139,7 +1538,7 @@ GPSDriverUBX::parseChar(const uint8_t b)
 
 	case UBX_DECODE_RTCM3:
 		if (_rtcm_parsing->addByte(b)) {
-			UBX_DEBUG("got RTCM message with length %i", static_cast<int>(_rtcm_parsing->messageLength()));
+			UBX_DEBUG("got RTCM message with length %i", (int)_rtcm_parsing->messageLength());
 			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
 			decodeInit();
 		}
@@ -1188,31 +1587,31 @@ GPSDriverUBX::payloadRxInit()
 
 		break;
 
-	case UBX_MSG_NAV_POSLLH:
-		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_posllh_t)) {
-			_rx_state = UBX_RXMSG_ERROR_LENGTH;
+	// case UBX_MSG_NAV_POSLLH:
+	// 	if (_rx_payload_length != sizeof(ubx_payload_rx_nav_posllh_t)) {
+	// 		_rx_state = UBX_RXMSG_ERROR_LENGTH;
 
-		} else if (!_configured) {
-			_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
+	// 	} else if (!_configured) {
+	// 		_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
 
-		} else if (_use_nav_pvt) {
-			_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
-		}
+	// 	} else if (_use_nav_pvt) {
+	// 		_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
+	// 	}
 
-		break;
+	// 	break;
 
-	case UBX_MSG_NAV_SOL:
-		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_sol_t)) {
-			_rx_state = UBX_RXMSG_ERROR_LENGTH;
+	// case UBX_MSG_NAV_SOL:
+	// 	if (_rx_payload_length != sizeof(ubx_payload_rx_nav_sol_t)) {
+	// 		_rx_state = UBX_RXMSG_ERROR_LENGTH;
 
-		} else if (!_configured) {
-			_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
+	// 	} else if (!_configured) {
+	// 		_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
 
-		} else if (_use_nav_pvt) {
-			_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
-		}
+	// 	} else if (_use_nav_pvt) {
+	// 		_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
+	// 	}
 
-		break;
+	// 	break;
 
 	case UBX_MSG_NAV_DOP:
 		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_dop_t)) {
@@ -1225,35 +1624,23 @@ GPSDriverUBX::payloadRxInit()
 
 		break;
 
-	case UBX_MSG_NAV_RELPOSNED:
-		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_relposned_t)) {
-			_rx_state = UBX_RXMSG_ERROR_LENGTH;
+	// case UBX_MSG_NAV_TIMEUTC:
+	// 	if (_rx_payload_length != sizeof(ubx_payload_rx_nav_timeutc_t)) {
+	// 		_rx_state = UBX_RXMSG_ERROR_LENGTH;
 
-		} else if (!_configured) {
-			_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
+	// 	} else if (!_configured) {
+	// 		_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
 
-		}
+	// 	} else if (_use_nav_pvt) {
+	// 		_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
+	// 	}
 
-		break;
-
-	case UBX_MSG_NAV_TIMEUTC:
-		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_timeutc_t)) {
-			_rx_state = UBX_RXMSG_ERROR_LENGTH;
-
-		} else if (!_configured) {
-			_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
-
-		} else if (_use_nav_pvt) {
-			_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
-		}
-
-		break;
+	// 	break;
 
 	case UBX_MSG_NAV_SAT:
 	case UBX_MSG_NAV_SVINFO:
 		if (_satellite_info == nullptr) {
 			_rx_state = UBX_RXMSG_DISABLE;        // disable if sat info not requested
-
 		} else if (!_configured) {
 			_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
 
@@ -1274,16 +1661,16 @@ GPSDriverUBX::payloadRxInit()
 
 		break;
 
-	case UBX_MSG_NAV_VELNED:
-		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_velned_t)) {
-			_rx_state = UBX_RXMSG_ERROR_LENGTH;
+	// case UBX_MSG_NAV_VELNED:
+	// 	if (_rx_payload_length != sizeof(ubx_payload_rx_nav_velned_t)) {
+	// 		_rx_state = UBX_RXMSG_ERROR_LENGTH;
 
-		} else if (!_configured) {
-			_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
+	// 	} else if (!_configured) {
+	// 		_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
 
-		} else if (_use_nav_pvt) {
-			_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
-		}
+	// 	} else if (_use_nav_pvt) {
+	// 		_rx_state = UBX_RXMSG_DISABLE;        // disable if using NAV-PVT instead
+	// 	}
 
 		break;
 
@@ -1334,7 +1721,8 @@ GPSDriverUBX::payloadRxInit()
 		break;
 
 	default:
-		_rx_state = UBX_RXMSG_DISABLE;	// disable all other messages
+		//_rx_state = UBX_RXMSG_DISABLE;	// disable all other messages
+		_rx_state = UBX_RXMSG_IGNORE;	// disable all other messages
 		break;
 	}
 
@@ -1344,51 +1732,25 @@ GPSDriverUBX::payloadRxInit()
 		ret = 0;
 		break;
 
-	case UBX_RXMSG_DISABLE:	// disable unexpected messages
-		UBX_DEBUG("ubx msg 0x%04x len %u unexpected", SWAP16((unsigned)_rx_msg), (unsigned)_rx_payload_length);
+	// case UBX_RXMSG_DISABLE:	// disable unexpected messages
+	// 	UBX_DEBUG("ubx msg 0x%04x len %u unexpected", SWAP16((unsigned)_rx_msg), (unsigned)_rx_payload_length);
 
-		if (_proto_ver_27_or_higher) {
-			uint32_t key_id = 0;
+	// 	if (!_proto_ver_27_or_higher) { // we cannot infer the config Key ID from _rx_msg for protocol version 27+
+	// 		gps_abstime t = gps_absolute_time();
 
-			switch (_rx_msg) { // we cannot infer the config Key ID from _rx_msg for protocol version 27+
-			case UBX_MSG_RXM_RAWX:
-				key_id = UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C;
-				break;
+	// 		if (t > _disable_cmd_last + DISABLE_MSG_INTERVAL) {
+	// 			/* don't attempt for every message to disable, some might not be disabled */
+	// 			_disable_cmd_last = t;
+	// 			UBX_DEBUG("ubx disabling msg 0x%04x", SWAP16((unsigned)_rx_msg));
 
-			case UBX_MSG_RXM_SFRBX:
-				key_id = UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C;
-				break;
-			}
+	// 			if (!configureMessageRate(_rx_msg, 0)) {
+	// 				ret = -1;
+	// 			}
+	// 		}
+	// 	}
 
-			if (key_id != 0) {
-				gps_abstime t = gps_absolute_time();
-
-				if (t > _disable_cmd_last + DISABLE_MSG_INTERVAL && _configured) {
-					/* don't attempt for every message to disable, some might not be disabled */
-					_disable_cmd_last = t;
-					UBX_DEBUG("ubx disabling msg 0x%04x (0x%04x)", SWAP16((unsigned)_rx_msg), key_id);
-
-					// this will overwrite _buf, which is fine, as we'll return -1 and abort further parsing
-					int cfg_valset_msg_size = initCfgValset();
-					cfgValsetPort(key_id, 0, cfg_valset_msg_size);
-					sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
-				}
-			}
-
-		} else {
-			gps_abstime t = gps_absolute_time();
-
-			if (t > _disable_cmd_last + DISABLE_MSG_INTERVAL) {
-				/* don't attempt for every message to disable, some might not be disabled */
-				_disable_cmd_last = t;
-				UBX_DEBUG("ubx disabling msg 0x%04x", SWAP16((unsigned)_rx_msg));
-
-				configureMessageRate(_rx_msg, 0);
-			}
-		}
-
-		ret = -1;	// return error, abort handling this message
-		break;
+	// 	ret = -1;	// return error, abort handling this message
+	// 	break;
 
 	case UBX_RXMSG_ERROR_LENGTH:	// error: invalid length
 		UBX_WARN("ubx msg 0x%04x invalid len %u", SWAP16((unsigned)_rx_msg), (unsigned)_rx_payload_length);
@@ -1449,84 +1811,20 @@ GPSDriverUBX::payloadRxAddNavSat(const uint8_t b)
 
 			if (buf_index == sizeof(ubx_payload_rx_nav_sat_part2_t) - 1) {
 				// Part 2 complete: decode Part 2 buffer
-				unsigned sat_index = (_rx_payload_index - sizeof(ubx_payload_rx_nav_sat_part1_t)) /
-						     sizeof(ubx_payload_rx_nav_sat_part2_t);
-
-				// convert gnssId:svId to a 8 bit number (use svId numbering from NAV-SVINFO)
-				uint8_t ubx_sat_gnssId = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.gnssId);
-				uint8_t ubx_sat_svId = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.svId);
-
-				uint8_t svinfo_svid = 255;
-
-				switch (ubx_sat_gnssId) {
-				case 0:  // GPS: G1-G23 -> 1-32
-					if (ubx_sat_svId >= 1 && ubx_sat_svId <= 32) {
-						svinfo_svid = ubx_sat_svId;
-					}
-
-					break;
-
-				case 1:  // SBAS: S120-S158 -> 120-158
-					if (ubx_sat_svId >= 120 && ubx_sat_svId <= 158) {
-						svinfo_svid = ubx_sat_svId;
-					}
-
-					break;
-
-				case 2:  // Galileo: E1-E36 -> 211-246
-					if (ubx_sat_svId >= 1 && ubx_sat_svId <= 36) {
-						svinfo_svid = ubx_sat_svId + 210;
-					}
-
-					break;
-
-				case 3:  // BeiDou: B1-B37 -> 159-163,33-64
-					if (ubx_sat_svId >= 1 && ubx_sat_svId <= 4) {
-						svinfo_svid = ubx_sat_svId + 158;
-
-					} else if (ubx_sat_svId >= 5 && ubx_sat_svId <= 37) {
-						svinfo_svid = ubx_sat_svId + 28;
-					}
-
-					break;
-
-				case 4:  // IMES: I1-I10 -> 173-182
-					if (ubx_sat_svId >= 1 && ubx_sat_svId <= 10) {
-						svinfo_svid = ubx_sat_svId + 172;
-					}
-
-					break;
-
-				case 5:  // QZSS: Q1-A10 -> 193-202
-					if (ubx_sat_svId >= 1 && ubx_sat_svId <= 10) {
-						svinfo_svid = ubx_sat_svId + 192;
-					}
-
-					break;
-
-				case 6:  // GLONASS: R1-R32 -> 65-96, R? -> 255
-					if (ubx_sat_svId >= 1 && ubx_sat_svId <= 32) {
-						svinfo_svid = ubx_sat_svId + 64;
-					}
-
-					break;
-				}
-
-				_satellite_info->svid[sat_index]	  = svinfo_svid;
-				_satellite_info->used[sat_index]	  = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.flags & 0x01);
-				_satellite_info->elevation[sat_index] = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.elev);
-				_satellite_info->azimuth[sat_index]	  = static_cast<uint8_t>(static_cast<float>(_buf.payload_rx_nav_sat_part2.azim) *
-						255.0f / 360.0f);
-				_satellite_info->snr[sat_index]		  = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.cno);
-				_satellite_info->prn[sat_index]		  = svinfo_svid;
-				UBX_TRACE_SVINFO("SAT #%02u  svid %3u  used %u  elevation %3u  azimuth %3u  snr %3u  prn %3u",
-						 static_cast<unsigned>(sat_index + 1),
-						 static_cast<unsigned>(_satellite_info->svid[sat_index]),
-						 static_cast<unsigned>(_satellite_info->used[sat_index]),
-						 static_cast<unsigned>(_satellite_info->elevation[sat_index]),
-						 static_cast<unsigned>(_satellite_info->azimuth[sat_index]),
-						 static_cast<unsigned>(_satellite_info->snr[sat_index]),
-						 static_cast<unsigned>(_satellite_info->prn[sat_index])
+				unsigned sat_index = (_rx_payload_index - sizeof(ubx_payload_rx_nav_sat_part1_t)) / sizeof(
+							     ubx_payload_rx_nav_sat_part2_t);
+				_satellite_info->used[sat_index]	= (uint8_t)(_buf.payload_rx_nav_sat_part2.flags & 0x01);
+				_satellite_info->snr[sat_index]		= (uint8_t)(_buf.payload_rx_nav_sat_part2.cno);
+				_satellite_info->elevation[sat_index]	= (uint8_t)(_buf.payload_rx_nav_sat_part2.elev);
+				_satellite_info->azimuth[sat_index]	= (uint8_t)((float)_buf.payload_rx_nav_sat_part2.azim * 255.0f / 360.0f);
+				_satellite_info->svid[sat_index]	= (uint8_t)(_buf.payload_rx_nav_sat_part2.svId);
+				UBX_TRACE_SVINFO("SAT #%02u  used %u  snr %3u  elevation %3u  azimuth %3u  svid %3u",
+						 (unsigned)sat_index + 1,
+						 (unsigned)_satellite_info->used[sat_index],
+						 (unsigned)_satellite_info->snr[sat_index],
+						 (unsigned)_satellite_info->elevation[sat_index],
+						 (unsigned)_satellite_info->azimuth[sat_index],
+						 (unsigned)_satellite_info->svid[sat_index]
 						);
 			}
 		}
@@ -1538,7 +1836,6 @@ GPSDriverUBX::payloadRxAddNavSat(const uint8_t b)
 
 	return ret;
 }
-
 /**
  * Add NAV-SVINFO payload rx byte
  */
@@ -1569,24 +1866,20 @@ GPSDriverUBX::payloadRxAddNavSvinfo(const uint8_t b)
 
 			if (buf_index == sizeof(ubx_payload_rx_nav_svinfo_part2_t) - 1) {
 				// Part 2 complete: decode Part 2 buffer
-				unsigned sat_index = (_rx_payload_index - sizeof(ubx_payload_rx_nav_svinfo_part1_t)) /
-						     sizeof(ubx_payload_rx_nav_svinfo_part2_t);
-				_satellite_info->svid[sat_index]      = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.svid);
-				_satellite_info->used[sat_index]      = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.flags & 0x01);
-				_satellite_info->elevation[sat_index] = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.elev);
-				_satellite_info->azimuth[sat_index]   = static_cast<uint8_t>(static_cast<float>(_buf.payload_rx_nav_svinfo_part2.azim) *
-									255.0f / 360.0f);
-				_satellite_info->snr[sat_index]       = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.cno);
-				_satellite_info->prn[sat_index]       = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.svid);
-
-				UBX_TRACE_SVINFO("SVINFO #%02u  svid %3u  used %u  elevation %3u  azimuth %3u  snr %3u  prn %3u",
-						 static_cast<unsigned>(sat_index + 1),
-						 static_cast<unsigned>(_satellite_info->svid[sat_index]),
-						 static_cast<unsigned>(_satellite_info->used[sat_index]),
-						 static_cast<unsigned>(_satellite_info->elevation[sat_index]),
-						 static_cast<unsigned>(_satellite_info->azimuth[sat_index]),
-						 static_cast<unsigned>(_satellite_info->snr[sat_index]),
-						 static_cast<unsigned>(_satellite_info->prn[sat_index])
+				unsigned sat_index = (_rx_payload_index - sizeof(ubx_payload_rx_nav_svinfo_part1_t)) / sizeof(
+							     ubx_payload_rx_nav_svinfo_part2_t);
+				_satellite_info->used[sat_index]	= (uint8_t)(_buf.payload_rx_nav_svinfo_part2.flags & 0x01);
+				_satellite_info->snr[sat_index]		= (uint8_t)(_buf.payload_rx_nav_svinfo_part2.cno);
+				_satellite_info->elevation[sat_index]	= (uint8_t)(_buf.payload_rx_nav_svinfo_part2.elev);
+				_satellite_info->azimuth[sat_index]	= (uint8_t)((float)_buf.payload_rx_nav_svinfo_part2.azim * 255.0f / 360.0f);
+				_satellite_info->svid[sat_index]	= (uint8_t)(_buf.payload_rx_nav_svinfo_part2.svid);
+				UBX_TRACE_SVINFO("SVINFO #%02u  used %u  snr %3u  elevation %3u  azimuth %3u  svid %3u",
+						 (unsigned)sat_index + 1,
+						 (unsigned)_satellite_info->used[sat_index],
+						 (unsigned)_satellite_info->snr[sat_index],
+						 (unsigned)_satellite_info->elevation[sat_index],
+						 (unsigned)_satellite_info->azimuth[sat_index],
+						 (unsigned)_satellite_info->svid[sat_index]
 						);
 			}
 		}
@@ -1642,11 +1935,15 @@ GPSDriverUBX::payloadRxAddMonVer(const uint8_t b)
 					   sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
 				_board = Board::u_blox9;
 
+			} else if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "000A0000",
+					sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
+			_board = Board::u_blox10;
+
 			} else {
 				UBX_WARN("unknown board hw: %s", _buf.payload_rx_mon_ver_part1.hwVersion);
 			}
 
-			UBX_DEBUG("detected board: %i", static_cast<int>(_board));
+			UBX_DEBUG("detected board: %i", (int)_board);
 		}
 
 		// fill Part 2 buffer
@@ -1726,18 +2023,18 @@ GPSDriverUBX::payloadRxDone()
 		_gps_position->alt		= _buf.payload_rx_nav_pvt.hMSL;
 		_gps_position->alt_ellipsoid	= _buf.payload_rx_nav_pvt.height;
 
-		_gps_position->eph		= static_cast<float>(_buf.payload_rx_nav_pvt.hAcc) * 1e-3f;
-		_gps_position->epv		= static_cast<float>(_buf.payload_rx_nav_pvt.vAcc) * 1e-3f;
-		_gps_position->s_variance_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.sAcc) * 1e-3f;
+		_gps_position->eph		= (float)_buf.payload_rx_nav_pvt.hAcc * 1e-3f;
+		_gps_position->epv		= (float)_buf.payload_rx_nav_pvt.vAcc * 1e-3f;
+		_gps_position->s_variance_m_s	= (float)_buf.payload_rx_nav_pvt.sAcc * 1e-3f;
 
-		_gps_position->vel_m_s		= static_cast<float>(_buf.payload_rx_nav_pvt.gSpeed) * 1e-3f;
+		_gps_position->vel_m_s		= (float)_buf.payload_rx_nav_pvt.gSpeed * 1e-3f;
 
-		_gps_position->vel_n_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.velN) * 1e-3f;
-		_gps_position->vel_e_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.velE) * 1e-3f;
-		_gps_position->vel_d_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.velD) * 1e-3f;
+		_gps_position->vel_n_m_s	= (float)_buf.payload_rx_nav_pvt.velN * 1e-3f;
+		_gps_position->vel_e_m_s	= (float)_buf.payload_rx_nav_pvt.velE * 1e-3f;
+		_gps_position->vel_d_m_s	= (float)_buf.payload_rx_nav_pvt.velD * 1e-3f;
 
-		_gps_position->cog_rad		= static_cast<float>(_buf.payload_rx_nav_pvt.headMot) * M_DEG_TO_RAD_F * 1e-5f;
-		_gps_position->c_variance_rad	= static_cast<float>(_buf.payload_rx_nav_pvt.headAcc) * M_DEG_TO_RAD_F * 1e-5f;
+		_gps_position->cog_rad		= (float)_buf.payload_rx_nav_pvt.headMot * M_DEG_TO_RAD_F * 1e-5f;
+		_gps_position->c_variance_rad	= (float)_buf.payload_rx_nav_pvt.headAcc * M_DEG_TO_RAD_F * 1e-5f;
 
 		//Check if time and date fix flags are good
 		if ((_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_VALIDDATE)
@@ -1812,8 +2109,8 @@ GPSDriverUBX::payloadRxDone()
 		_gps_position->lat	= _buf.payload_rx_nav_posllh.lat;
 		_gps_position->lon	= _buf.payload_rx_nav_posllh.lon;
 		_gps_position->alt	= _buf.payload_rx_nav_posllh.hMSL;
-		_gps_position->eph	= static_cast<float>(_buf.payload_rx_nav_posllh.hAcc) * 1e-3f; // from mm to m
-		_gps_position->epv	= static_cast<float>(_buf.payload_rx_nav_posllh.vAcc) * 1e-3f; // from mm to m
+		_gps_position->eph	= (float)_buf.payload_rx_nav_posllh.hAcc * 1e-3f; // from mm to m
+		_gps_position->epv	= (float)_buf.payload_rx_nav_posllh.vAcc * 1e-3f; // from mm to m
 		_gps_position->alt_ellipsoid = _buf.payload_rx_nav_posllh.height;
 
 		_gps_position->timestamp = gps_absolute_time();
@@ -1824,15 +2121,15 @@ GPSDriverUBX::payloadRxDone()
 		ret = 1;
 		break;
 
-	case UBX_MSG_NAV_SOL:
-		UBX_TRACE_RXMSG("Rx NAV-SOL");
+	// case UBX_MSG_NAV_SOL:
+	// 	UBX_TRACE_RXMSG("Rx NAV-SOL");
 
-		_gps_position->fix_type		= _buf.payload_rx_nav_sol.gpsFix;
-		_gps_position->s_variance_m_s	= static_cast<float>(_buf.payload_rx_nav_sol.sAcc) * 1e-2f;	// from cm to m
-		_gps_position->satellites_used	= _buf.payload_rx_nav_sol.numSV;
+	// 	_gps_position->fix_type		= _buf.payload_rx_nav_sol.gpsFix;
+	// 	_gps_position->s_variance_m_s	= (float)_buf.payload_rx_nav_sol.sAcc * 1e-2f;	// from cm to m
+	// 	_gps_position->satellites_used	= _buf.payload_rx_nav_sol.numSV;
 
-		ret = 1;
-		break;
+	// 	ret = 1;
+	// 	break;
 
 	case UBX_MSG_NAV_DOP:
 		UBX_TRACE_RXMSG("Rx NAV-DOP");
@@ -1890,27 +2187,30 @@ GPSDriverUBX::payloadRxDone()
 		break;
 
 	case UBX_MSG_NAV_SAT:
-	case UBX_MSG_NAV_SVINFO:
-		UBX_TRACE_RXMSG("Rx NAV-SVINFO");
+	//case UBX_MSG_NAV_SVINFO:
+		UBX_TRACE_RXMSG("Rx NAV-SAT");
 
 		// _satellite_info already populated by payload_rx_add_svinfo(), just add a timestamp
+		/* in max-m10s gps payload_rx_add_svinfo() & UBX_MSG_NAV_SVINFO not used.
+		use payload_rx_add_sat() instead */
 		_satellite_info->timestamp = gps_absolute_time();
 
 		ret = 2;
 		break;
 
+	/* in max-m10s UBX_MSG_NAV_SVIN not used. */
 	case UBX_MSG_NAV_SVIN:
 		UBX_TRACE_RXMSG("Rx NAV-SVIN");
 		{
 			ubx_payload_rx_nav_svin_t &svin = _buf.payload_rx_nav_svin;
 
 			UBX_DEBUG("Survey-in status: %is cur accuracy: %imm nr obs: %i valid: %i active: %i",
-				  svin.dur, svin.meanAcc / 10, svin.obs, static_cast<int>(svin.valid), static_cast<int>(svin.active));
+				  svin.dur, svin.meanAcc / 10, svin.obs, (int)svin.valid, (int)svin.active);
 
 			SurveyInStatus status{};
-			double ecef_x = (static_cast<double>(svin.meanX) + static_cast<double>(svin.meanXHP) * 0.01) * 0.01;
-			double ecef_y = (static_cast<double>(svin.meanY) + static_cast<double>(svin.meanYHP) * 0.01) * 0.01;
-			double ecef_z = (static_cast<double>(svin.meanZ) + static_cast<double>(svin.meanZHP) * 0.01) * 0.01;
+			double ecef_x = ((double)svin.meanX + (double)svin.meanXHP * 0.01) * 0.01;
+			double ecef_y = ((double)svin.meanY + (double)svin.meanYHP * 0.01) * 0.01;
+			double ecef_z = ((double)svin.meanZ + (double)svin.meanZHP * 0.01) * 0.01;
 			ECEF2lla(ecef_x, ecef_y, ecef_z, status.latitude, status.longitude, status.altitude);
 			status.duration = svin.dur;
 			status.mean_accuracy = svin.meanAcc / 10;
@@ -1918,7 +2218,7 @@ GPSDriverUBX::payloadRxDone()
 			surveyInStatus(status);
 
 			if (svin.valid == 1 && svin.active == 0) {
-				if (activateRTCMOutput(true) != 0) {
+				if (activateRTCMOutput() != 0) {
 					return -1;
 				}
 			}
@@ -1930,49 +2230,18 @@ GPSDriverUBX::payloadRxDone()
 	case UBX_MSG_NAV_VELNED:
 		UBX_TRACE_RXMSG("Rx NAV-VELNED");
 
-		_gps_position->vel_m_s        = static_cast<float>(_buf.payload_rx_nav_velned.speed) * 1e-2f;
-		_gps_position->vel_n_m_s      = static_cast<float>(_buf.payload_rx_nav_velned.velN)  * 1e-2f; // NED NORTH velocity
-		_gps_position->vel_e_m_s      = static_cast<float>(_buf.payload_rx_nav_velned.velE)  * 1e-2f; // NED EAST velocity
-		_gps_position->vel_d_m_s      = static_cast<float>(_buf.payload_rx_nav_velned.velD)  * 1e-2f; // NED DOWN velocity
-		_gps_position->cog_rad        = static_cast<float>(_buf.payload_rx_nav_velned.heading) * M_DEG_TO_RAD_F * 1e-5f;
-		_gps_position->c_variance_rad = static_cast<float>(_buf.payload_rx_nav_velned.cAcc)    * M_DEG_TO_RAD_F * 1e-5f;
-		_gps_position->vel_ned_valid  = true;
+		_gps_position->vel_m_s		= (float)_buf.payload_rx_nav_velned.speed * 1e-2f;
+		_gps_position->vel_n_m_s	= (float)_buf.payload_rx_nav_velned.velN * 1e-2f; /* NED NORTH velocity */
+		_gps_position->vel_e_m_s	= (float)_buf.payload_rx_nav_velned.velE * 1e-2f; /* NED EAST velocity */
+		_gps_position->vel_d_m_s	= (float)_buf.payload_rx_nav_velned.velD * 1e-2f; /* NED DOWN velocity */
+		_gps_position->cog_rad		= (float)_buf.payload_rx_nav_velned.heading * M_DEG_TO_RAD_F * 1e-5f;
+		_gps_position->c_variance_rad	= (float)_buf.payload_rx_nav_velned.cAcc * M_DEG_TO_RAD_F * 1e-5f;
+		_gps_position->vel_ned_valid	= true;
 
 		_rate_count_vel++;
 		_got_velned = true;
 
 		ret = 1;
-		break;
-
-	case UBX_MSG_NAV_RELPOSNED:
-		UBX_TRACE_RXMSG("Rx NAV-RELPOSNED");
-
-		if (_mode == UBXMode::RoverWithMovingBase) {
-			float heading = _buf.payload_rx_nav_relposned.relPosHeading * 1e-5f;
-			float heading_acc = _buf.payload_rx_nav_relposned.accHeading * 1e-5f;
-			float rel_length = _buf.payload_rx_nav_relposned.relPosLength + _buf.payload_rx_nav_relposned.relPosHPLength * 1e-2f;
-			float rel_length_acc = _buf.payload_rx_nav_relposned.accLength * 1e-2f;
-			bool heading_valid = _buf.payload_rx_nav_relposned.flags & (1 << 8);
-			bool rel_pos_valid = _buf.payload_rx_nav_relposned.flags & (1 << 2);
-			(void)heading_acc;
-			(void)rel_length_acc;
-			UBX_DEBUG("Heading: %.1f deg, acc: %.1f deg, relLen: %.1f cm, relAcc: %.1f cm, valid: %i %i", (double)heading,
-				  (double)heading_acc, (double)rel_length, (double)rel_length_acc, heading_valid, rel_pos_valid);
-
-			if (heading_valid && rel_pos_valid && rel_length < 1000.f) { // validity & sanity checks
-				heading *= M_PI_F / 180.0f; // deg to rad, now in range [0, 2pi]
-				heading -= _heading_offset; // range: [-pi, 3pi]
-
-				if (heading > M_PI_F) {
-					heading -= 2.f * M_PI_F; // final range is [-pi, pi]
-				}
-
-				_gps_position->heading = heading;
-			}
-
-			ret = 1;
-		}
-
 		break;
 
 	case UBX_MSG_MON_VER:
@@ -1993,7 +2262,6 @@ GPSDriverUBX::payloadRxDone()
 
 		case sizeof(ubx_payload_rx_mon_hw_ubx6_t):	/* u-blox 6 msg format */
 			_gps_position->noise_per_ms		= _buf.payload_rx_mon_hw_ubx6.noisePerMS;
-			_gps_position->automatic_gain_control   = _buf.payload_rx_mon_hw_ubx6.agcCnt;
 			_gps_position->jamming_indicator	= _buf.payload_rx_mon_hw_ubx6.jamInd;
 
 			ret = 1;
@@ -2001,7 +2269,6 @@ GPSDriverUBX::payloadRxDone()
 
 		case sizeof(ubx_payload_rx_mon_hw_ubx7_t):	/* u-blox 7+ msg format */
 			_gps_position->noise_per_ms		= _buf.payload_rx_mon_hw_ubx7.noisePerMS;
-			_gps_position->automatic_gain_control   = _buf.payload_rx_mon_hw_ubx7.agcCnt;
 			_gps_position->jamming_indicator	= _buf.payload_rx_mon_hw_ubx7.jamInd;
 
 			ret = 1;
@@ -2019,7 +2286,6 @@ GPSDriverUBX::payloadRxDone()
 
 		_gps_position->noise_per_ms		= _buf.payload_rx_mon_rf.block[0].noisePerMS;
 		_gps_position->jamming_indicator	= _buf.payload_rx_mon_rf.block[0].jamInd;
-		_gps_position->jamming_state		= _buf.payload_rx_mon_rf.block[0].flags;
 
 		ret = 1;
 		break;
@@ -2056,18 +2322,15 @@ GPSDriverUBX::payloadRxDone()
 }
 
 int
-GPSDriverUBX::activateRTCMOutput(bool reduce_update_rate)
+GPSDriverUBX::activateRTCMOutput()
 {
-	/* For base stations we switch to 1 Hz update rate, which is enough for RTCM output.
+	/* We now switch to 1 Hz update rate, which is enough for RTCM output.
 	 * For the survey-in, we still want 5/10 Hz, because this speeds up the process */
 
 	if (_proto_ver_27_or_higher) {
 		int cfg_valset_msg_size = initCfgValset();
 
-		if (reduce_update_rate) {
-			cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, 1000, cfg_valset_msg_size);
-		}
-
+		cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, 1000, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 5, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 1, cfg_valset_msg_size);
@@ -2086,16 +2349,18 @@ GPSDriverUBX::activateRTCMOutput(bool reduce_update_rate)
 
 	} else {
 
-		if (reduce_update_rate) {
-			memset(&_buf.payload_tx_cfg_rate, 0, sizeof(_buf.payload_tx_cfg_rate));
-			_buf.payload_tx_cfg_rate.measRate	= 1000;
-			_buf.payload_tx_cfg_rate.navRate	= UBX_TX_CFG_RATE_NAVRATE;
-			_buf.payload_tx_cfg_rate.timeRef	= UBX_TX_CFG_RATE_TIMEREF;
+		memset(&_buf.payload_tx_cfg_rate, 0, sizeof(_buf.payload_tx_cfg_rate));
+		_buf.payload_tx_cfg_rate.measRate	= 1000;
+		_buf.payload_tx_cfg_rate.navRate	= UBX_TX_CFG_RATE_NAVRATE;
+		_buf.payload_tx_cfg_rate.timeRef	= UBX_TX_CFG_RATE_TIMEREF;
 
-			if (!sendMessage(UBX_MSG_CFG_RATE, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_rate))) { return -1; }
+		if (!sendMessage(UBX_MSG_CFG_RATE, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_rate))) { return -1; }
 
-			// according to the spec we should receive an (N)ACK here, but we don't
-		}
+		// according to the spec we should receive an (N)ACK here, but we don't
+//		decodeInit();
+//		if (waitForAck(UBX_MSG_CFG_RATE, UBX_CONFIG_TIMEOUT, true) < 0) {
+//			return -1;
+//		}
 
 		configureMessageRate(UBX_MSG_NAV_SVIN, 0);
 
@@ -2130,14 +2395,12 @@ GPSDriverUBX::decodeInit()
 	_rx_payload_length = 0;
 	_rx_payload_index = 0;
 
-	if (_output_mode == OutputMode::GPSAndRTCM || _output_mode == OutputMode::RTCM) {
+	if (_output_mode == OutputMode::RTCM) {
 		if (!_rtcm_parsing) {
 			_rtcm_parsing = new RTCMParsing();
 		}
 
-		if (_rtcm_parsing) {
-			_rtcm_parsing->reset();
-		}
+		_rtcm_parsing->reset();
 	}
 }
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -45,347 +45,290 @@
  * @author Hannes Delago
  *   (rework, add ubx7+ compatibility)
  *
+ * @author Ilya Sopkin <ivsopkin@outlook.com>
+ *	 (added beta version of u-blox MAX-M10S gps module)
+ *
  */
 
 #pragma once
 
-#include "base_station.h"
 #include "gps_helper.h"
+#include "base_station.h"
 #include "../../definitions.h"
 
-
-#define UBX_CONFIG_TIMEOUT    250 // ms, timeout for waiting ACK
-#define UBX_PACKET_TIMEOUT    2   // ms, if now data during this delay assume that full update received
-
-#define DISABLE_MSG_INTERVAL  1000000    // us, try to disable message with this interval
-
-#define FNV1_32_INIT          static_cast<uint32_t>(0x811c9dc5)    // init value for FNV1 hash algorithm
-#define FNV1_32_PRIME         static_cast<uint32_t>(0x01000193)    // magic prime for FNV1 hash algorithm
-
-#define UBX_SYNC1             0xB5
-#define UBX_SYNC2             0x62
+#define UBX_SYNC1 0xB5
+#define UBX_SYNC2 0x62
 
 /* Message Classes */
-#define UBX_CLASS_NAV         0x01
-#define UBX_CLASS_RXM         0x02
-#define UBX_CLASS_INF         0x04
-#define UBX_CLASS_ACK         0x05
-#define UBX_CLASS_CFG         0x06
-#define UBX_CLASS_MON         0x0A
-#define UBX_CLASS_RTCM3       0xF5
+#define UBX_CLASS_NAV		0x01
+#define UBX_CLASS_INF		0x04
+#define UBX_CLASS_ACK		0x05
+#define UBX_CLASS_CFG		0x06
+#define UBX_CLASS_MON		0x0A
+#define UBX_CLASS_RTCM3	0xF5
 
 /* Message IDs */
-#define UBX_ID_NAV_POSLLH     0x02
-#define UBX_ID_NAV_DOP        0x04
-#define UBX_ID_NAV_SOL        0x06
-#define UBX_ID_NAV_PVT        0x07
-#define UBX_ID_NAV_VELNED     0x12
-#define UBX_ID_NAV_TIMEUTC    0x21
-#define UBX_ID_NAV_SVINFO     0x30
-#define UBX_ID_NAV_SAT        0x35
-#define UBX_ID_NAV_SVIN       0x3B
-#define UBX_ID_NAV_RELPOSNED  0x3C
-#define UBX_ID_RXM_SFRBX      0x13
-#define UBX_ID_RXM_RAWX       0x15
-#define UBX_ID_INF_DEBUG      0x04
-#define UBX_ID_INF_ERROR      0x00
-#define UBX_ID_INF_NOTICE     0x02
-#define UBX_ID_INF_WARNING    0x01
-#define UBX_ID_ACK_NAK        0x00
-#define UBX_ID_ACK_ACK        0x01
-#define UBX_ID_CFG_PRT        0x00 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_MSG        0x01 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_RATE       0x08 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_CFG        0x09 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_NAV5       0x24 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_RST        0x04
-#define UBX_ID_CFG_SBAS       0x16
-#define UBX_ID_CFG_TMODE3     0x71 // deprecated in protocol version >= 27 -> use CFG_VALSET
-#define UBX_ID_CFG_GNSS       0x3E
-#define UBX_ID_CFG_VALSET     0x8A
-#define UBX_ID_CFG_VALGET     0x8B
-#define UBX_ID_CFG_VALDEL     0x8C
-#define UBX_ID_MON_VER        0x04
-#define UBX_ID_MON_HW         0x09 // deprecated in protocol version >= 27 -> use MON_RF
-#define UBX_ID_MON_RF         0x38
+#define UBX_ID_NAV_POSLLH	0x02
+#define UBX_ID_NAV_DOP		0x04
+#define UBX_ID_NAV_SOL		0x06
+#define UBX_ID_NAV_PVT		0x07
+#define UBX_ID_NAV_VELNED	0x12
+#define UBX_ID_NAV_TIMEUTC	0x21
+#define UBX_ID_NAV_SVINFO	0x30
+#define UBX_ID_NAV_SAT		0x35
+#define UBX_ID_NAV_SVIN  	0x3B
+#define UBX_ID_NAV_RELPOSNED  	0x3C
+#define UBX_ID_INF_DEBUG  	0x04
+#define UBX_ID_INF_ERROR  	0x00
+#define UBX_ID_INF_NOTICE  	0x02
+#define UBX_ID_INF_WARNING 	0x01
+#define UBX_ID_ACK_NAK		0x00
+#define UBX_ID_ACK_ACK		0x01
+#define UBX_ID_CFG_PRT		0x00 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_MSG		0x01 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_RATE	0x08 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_CFG		0x09 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_NAV5	0x24 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_RST	0x04
+#define UBX_ID_CFG_SBAS	0x16
+#define UBX_ID_CFG_TMODE3	0x71 // deprecated in protocol version >= 27 -> use CFG_VALSET
+#define UBX_ID_CFG_VALSET	0x8A
+#define UBX_ID_CFG_VALGET	0x8B
+#define UBX_ID_CFG_VALDEL	0x8C
+#define UBX_ID_MON_VER		0x04
+#define UBX_ID_MON_HW		0x09 // deprecated in protocol version >= 27 -> use MON_RF
+#define UBX_ID_MON_RF		0x38
 
 /* UBX ID for RTCM3 output messages */
 /* Minimal messages for RTK: 1005, 1077 + (1087 or 1127) */
 /* Reduced message size using MSM4: 1005, 1074 + (1084 or 1124)  */
-#define UBX_ID_RTCM3_1005     0x05    /**< Stationary RTK reference station ARP */
-#define UBX_ID_RTCM3_1074     0x4A    /**< GPS MSM4 */
-#define UBX_ID_RTCM3_1077     0x4D    /**< GPS MSM7 */
-#define UBX_ID_RTCM3_1084     0x54    /**< GLONASS MSM4 */
-#define UBX_ID_RTCM3_1087     0x57    /**< GLONASS MSM7 */
-#define UBX_ID_RTCM3_1094     0x5E    /**< Galileo MSM4 */
-#define UBX_ID_RTCM3_1097     0x61    /**< Galileo MSM7 */
-#define UBX_ID_RTCM3_1124     0x7C    /**< BeiDou MSM4 */
-#define UBX_ID_RTCM3_1127     0x7F    /**< BeiDou MSM7 */
-#define UBX_ID_RTCM3_1230     0xE6    /**< GLONASS code-phase biases */
-#define UBX_ID_RTCM3_4072     0xFE    /**< Reference station PVT (u-blox proprietary RTCM Message) - Used for moving baseline */
+#define UBX_ID_RTCM3_1005	0x05	/**< Stationary RTK reference station ARP */
+#define UBX_ID_RTCM3_1074	0x4A	/**< GPS MSM4 */
+#define UBX_ID_RTCM3_1077	0x4D	/**< GPS MSM7 */
+#define UBX_ID_RTCM3_1084	0x54	/**< GLONASS MSM4 */
+#define UBX_ID_RTCM3_1087	0x57	/**< GLONASS MSM7 */
+#define UBX_ID_RTCM3_1094	0x5E	/**< Galileo MSM4 */
+#define UBX_ID_RTCM3_1097	0x61	/**< Galileo MSM7 */
+#define UBX_ID_RTCM3_1124	0x7C	/**< BeiDou MSM4 */
+#define UBX_ID_RTCM3_1127	0x7F	/**< BeiDou MSM7 */
+#define UBX_ID_RTCM3_1230	0xE6	/**< GLONASS code-phase biases */
+#define UBX_ID_RTCM3_4072	0xFE	/**< Reference station PVT (u-blox proprietary RTCM Message) - Used for moving baseline */
 
 
 /* Message Classes & IDs */
-#define UBX_MSG_NAV_POSLLH    ((UBX_CLASS_NAV) | UBX_ID_NAV_POSLLH << 8)
-#define UBX_MSG_NAV_SOL       ((UBX_CLASS_NAV) | UBX_ID_NAV_SOL << 8)
-#define UBX_MSG_NAV_DOP       ((UBX_CLASS_NAV) | UBX_ID_NAV_DOP << 8)
-#define UBX_MSG_NAV_PVT       ((UBX_CLASS_NAV) | UBX_ID_NAV_PVT << 8)
-#define UBX_MSG_NAV_VELNED    ((UBX_CLASS_NAV) | UBX_ID_NAV_VELNED << 8)
-#define UBX_MSG_NAV_TIMEUTC   ((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEUTC << 8)
-#define UBX_MSG_NAV_SVINFO    ((UBX_CLASS_NAV) | UBX_ID_NAV_SVINFO << 8)
-#define UBX_MSG_NAV_SAT       ((UBX_CLASS_NAV) | UBX_ID_NAV_SAT << 8)
-#define UBX_MSG_NAV_SVIN      ((UBX_CLASS_NAV) | UBX_ID_NAV_SVIN << 8)
-#define UBX_MSG_NAV_RELPOSNED ((UBX_CLASS_NAV) | UBX_ID_NAV_RELPOSNED << 8)
-#define UBX_MSG_RXM_SFRBX     ((UBX_CLASS_RXM) | UBX_ID_RXM_SFRBX << 8)
-#define UBX_MSG_RXM_RAWX      ((UBX_CLASS_RXM) | UBX_ID_RXM_RAWX << 8)
-#define UBX_MSG_INF_DEBUG     ((UBX_CLASS_INF) | UBX_ID_INF_DEBUG << 8)
-#define UBX_MSG_INF_ERROR     ((UBX_CLASS_INF) | UBX_ID_INF_ERROR << 8)
-#define UBX_MSG_INF_NOTICE    ((UBX_CLASS_INF) | UBX_ID_INF_NOTICE << 8)
-#define UBX_MSG_INF_WARNING   ((UBX_CLASS_INF) | UBX_ID_INF_WARNING << 8)
-#define UBX_MSG_ACK_NAK       ((UBX_CLASS_ACK) | UBX_ID_ACK_NAK << 8)
-#define UBX_MSG_ACK_ACK       ((UBX_CLASS_ACK) | UBX_ID_ACK_ACK << 8)
-#define UBX_MSG_CFG_PRT       ((UBX_CLASS_CFG) | UBX_ID_CFG_PRT << 8)
-#define UBX_MSG_CFG_MSG       ((UBX_CLASS_CFG) | UBX_ID_CFG_MSG << 8)
-#define UBX_MSG_CFG_RATE      ((UBX_CLASS_CFG) | UBX_ID_CFG_RATE << 8)
-#define UBX_MSG_CFG_CFG       ((UBX_CLASS_CFG) | UBX_ID_CFG_CFG << 8)
-#define UBX_MSG_CFG_NAV5      ((UBX_CLASS_CFG) | UBX_ID_CFG_NAV5 << 8)
-#define UBX_MSG_CFG_RST       ((UBX_CLASS_CFG) | UBX_ID_CFG_RST << 8)
-#define UBX_MSG_CFG_SBAS      ((UBX_CLASS_CFG) | UBX_ID_CFG_SBAS << 8)
-#define UBX_MSG_CFG_TMODE3    ((UBX_CLASS_CFG) | UBX_ID_CFG_TMODE3 << 8)
-#define UBX_MSG_CFG_GNSS      ((UBX_CLASS_CFG) | UBX_ID_CFG_GNSS << 8)
-#define UBX_MSG_CFG_VALGET    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALGET << 8)
-#define UBX_MSG_CFG_VALSET    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALSET << 8)
-#define UBX_MSG_CFG_VALDEL    ((UBX_CLASS_CFG) | UBX_ID_CFG_VALDEL << 8)
-#define UBX_MSG_MON_HW        ((UBX_CLASS_MON) | UBX_ID_MON_HW << 8)
-#define UBX_MSG_MON_VER       ((UBX_CLASS_MON) | UBX_ID_MON_VER << 8)
-#define UBX_MSG_MON_RF        ((UBX_CLASS_MON) | UBX_ID_MON_RF << 8)
-#define UBX_MSG_RTCM3_1005    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1005 << 8)
-#define UBX_MSG_RTCM3_1077    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1077 << 8)
-#define UBX_MSG_RTCM3_1087    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1087 << 8)
-#define UBX_MSG_RTCM3_1074    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1074 << 8)
-#define UBX_MSG_RTCM3_1084    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1084 << 8)
-#define UBX_MSG_RTCM3_1094    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1094 << 8)
-#define UBX_MSG_RTCM3_1097    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1097 << 8)
-#define UBX_MSG_RTCM3_1124    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1124 << 8)
-#define UBX_MSG_RTCM3_1127    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1127 << 8)
-#define UBX_MSG_RTCM3_1230    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1230 << 8)
-#define UBX_MSG_RTCM3_4072    ((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_4072 << 8)
+#define UBX_MSG_NAV_POSLLH	((UBX_CLASS_NAV) | UBX_ID_NAV_POSLLH << 8)
+#define UBX_MSG_NAV_SOL		((UBX_CLASS_NAV) | UBX_ID_NAV_SOL << 8)
+#define UBX_MSG_NAV_DOP		((UBX_CLASS_NAV) | UBX_ID_NAV_DOP << 8)
+#define UBX_MSG_NAV_PVT		((UBX_CLASS_NAV) | UBX_ID_NAV_PVT << 8)
+#define UBX_MSG_NAV_VELNED	((UBX_CLASS_NAV) | UBX_ID_NAV_VELNED << 8)
+#define UBX_MSG_NAV_TIMEUTC	((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEUTC << 8)
+#define UBX_MSG_NAV_SVINFO	((UBX_CLASS_NAV) | UBX_ID_NAV_SVINFO << 8)
+#define UBX_MSG_NAV_SAT	((UBX_CLASS_NAV) | UBX_ID_NAV_SAT << 8)
+#define UBX_MSG_NAV_SVIN	((UBX_CLASS_NAV) | UBX_ID_NAV_SVIN << 8)
+#define UBX_MSG_NAV_RELPOSNED	((UBX_CLASS_NAV) | UBX_ID_NAV_RELPOSNED << 8)
+#define UBX_MSG_INF_DEBUG	((UBX_CLASS_INF) | UBX_ID_INF_DEBUG << 8)
+#define UBX_MSG_INF_ERROR	((UBX_CLASS_INF) | UBX_ID_INF_ERROR << 8)
+#define UBX_MSG_INF_NOTICE	((UBX_CLASS_INF) | UBX_ID_INF_NOTICE << 8)
+#define UBX_MSG_INF_WARNING	((UBX_CLASS_INF) | UBX_ID_INF_WARNING << 8)
+#define UBX_MSG_ACK_NAK		((UBX_CLASS_ACK) | UBX_ID_ACK_NAK << 8)
+#define UBX_MSG_ACK_ACK		((UBX_CLASS_ACK) | UBX_ID_ACK_ACK << 8)
+#define UBX_MSG_CFG_PRT		((UBX_CLASS_CFG) | UBX_ID_CFG_PRT << 8)
+#define UBX_MSG_CFG_MSG		((UBX_CLASS_CFG) | UBX_ID_CFG_MSG << 8)
+#define UBX_MSG_CFG_RATE	((UBX_CLASS_CFG) | UBX_ID_CFG_RATE << 8)
+#define UBX_MSG_CFG_CFG		((UBX_CLASS_CFG) | UBX_ID_CFG_CFG << 8)
+#define UBX_MSG_CFG_NAV5	((UBX_CLASS_CFG) | UBX_ID_CFG_NAV5 << 8)
+#define UBX_MSG_CFG_RST 	((UBX_CLASS_CFG) | UBX_ID_CFG_RST << 8)
+#define UBX_MSG_CFG_SBAS	((UBX_CLASS_CFG) | UBX_ID_CFG_SBAS << 8)
+#define UBX_MSG_CFG_TMODE3	((UBX_CLASS_CFG) | UBX_ID_CFG_TMODE3 << 8)
+#define UBX_MSG_CFG_VALGET	((UBX_CLASS_CFG) | UBX_ID_CFG_VALGET << 8)
+#define UBX_MSG_CFG_VALSET	((UBX_CLASS_CFG) | UBX_ID_CFG_VALSET << 8)
+#define UBX_MSG_CFG_VALDEL	((UBX_CLASS_CFG) | UBX_ID_CFG_VALDEL << 8)
+#define UBX_MSG_MON_HW		((UBX_CLASS_MON) | UBX_ID_MON_HW << 8)
+#define UBX_MSG_MON_VER		((UBX_CLASS_MON) | UBX_ID_MON_VER << 8)
+#define UBX_MSG_MON_RF		((UBX_CLASS_MON) | UBX_ID_MON_RF << 8)
+#define UBX_MSG_RTCM3_1005	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1005 << 8)
+#define UBX_MSG_RTCM3_1077	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1077 << 8)
+#define UBX_MSG_RTCM3_1087	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1087 << 8)
+#define UBX_MSG_RTCM3_1074	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1074 << 8)
+#define UBX_MSG_RTCM3_1084	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1084 << 8)
+#define UBX_MSG_RTCM3_1094	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1094 << 8)
+#define UBX_MSG_RTCM3_1097	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1097 << 8)
+#define UBX_MSG_RTCM3_1124	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1124 << 8)
+#define UBX_MSG_RTCM3_1127	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1127 << 8)
+#define UBX_MSG_RTCM3_1230	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_1230 << 8)
+#define UBX_MSG_RTCM3_4072	((UBX_CLASS_RTCM3) | UBX_ID_RTCM3_4072 << 8)
 
 /* RX NAV-PVT message content details */
 /*   Bitfield "valid" masks */
-#define UBX_RX_NAV_PVT_VALID_VALIDDATE          0x01    /**< validDate (Valid UTC Date) */
-#define UBX_RX_NAV_PVT_VALID_VALIDTIME          0x02    /**< validTime (Valid UTC Time) */
-#define UBX_RX_NAV_PVT_VALID_FULLYRESOLVED      0x04    /**< fullyResolved (1 = UTC Time of Day has been fully resolved (no seconds uncertainty)) */
+#define UBX_RX_NAV_PVT_VALID_VALIDDATE		0x01	/**< validDate (Valid UTC Date) */
+#define UBX_RX_NAV_PVT_VALID_VALIDTIME		0x02	/**< validTime (Valid UTC Time) */
+#define UBX_RX_NAV_PVT_VALID_FULLYRESOLVED	0x04	/**< fullyResolved (1 = UTC Time of Day has been fully resolved (no seconds uncertainty)) */
 
 /*   Bitfield "flags" masks */
-#define UBX_RX_NAV_PVT_FLAGS_GNSSFIXOK          0x01    /**< gnssFixOK (A valid fix (i.e within DOP & accuracy masks)) */
-#define UBX_RX_NAV_PVT_FLAGS_DIFFSOLN           0x02    /**< diffSoln (1 if differential corrections were applied) */
-#define UBX_RX_NAV_PVT_FLAGS_PSMSTATE           0x1C    /**< psmState (Power Save Mode state (see Power Management)) */
-#define UBX_RX_NAV_PVT_FLAGS_HEADVEHVALID       0x20    /**< headVehValid (Heading of vehicle is valid) */
-#define UBX_RX_NAV_PVT_FLAGS_CARRSOLN           0xC0    /**< Carrier phase range solution (RTK mode) */
+#define UBX_RX_NAV_PVT_FLAGS_GNSSFIXOK		0x01	/**< gnssFixOK (A valid fix (i.e within DOP & accuracy masks)) */
+#define UBX_RX_NAV_PVT_FLAGS_DIFFSOLN		0x02	/**< diffSoln (1 if differential corrections were applied) */
+#define UBX_RX_NAV_PVT_FLAGS_PSMSTATE		0x1C	/**< psmState (Power Save Mode state (see Power Management)) */
+#define UBX_RX_NAV_PVT_FLAGS_HEADVEHVALID	0x20	/**< headVehValid (Heading of vehicle is valid) */
+#define UBX_RX_NAV_PVT_FLAGS_CARRSOLN		0xC0	/**< Carrier phase range solution (RTK mode) */
 
 /* RX NAV-TIMEUTC message content details */
 /*   Bitfield "valid" masks */
-#define UBX_RX_NAV_TIMEUTC_VALID_VALIDTOW       0x01    /**< validTOW (1 = Valid Time of Week) */
-#define UBX_RX_NAV_TIMEUTC_VALID_VALIDKWN       0x02    /**< validWKN (1 = Valid Week Number) */
-#define UBX_RX_NAV_TIMEUTC_VALID_VALIDUTC       0x04    /**< validUTC (1 = Valid UTC Time) */
-#define UBX_RX_NAV_TIMEUTC_VALID_UTCSTANDARD    0xF0    /**< utcStandard (0..15 = UTC standard identifier) */
+#define UBX_RX_NAV_TIMEUTC_VALID_VALIDTOW	0x01	/**< validTOW (1 = Valid Time of Week) */
+#define UBX_RX_NAV_TIMEUTC_VALID_VALIDKWN	0x02	/**< validWKN (1 = Valid Week Number) */
+#define UBX_RX_NAV_TIMEUTC_VALID_VALIDUTC	0x04	/**< validUTC (1 = Valid UTC Time) */
+#define UBX_RX_NAV_TIMEUTC_VALID_UTCSTANDARD	0xF0	/**< utcStandard (0..15 = UTC standard identifier) */
 
 /* TX CFG-PRT message contents
  * Note: not used with protocol version 27+ anymore
  */
-#define UBX_TX_CFG_PRT_PORTID                   0x01            /**< UART1 */
-#define UBX_TX_CFG_PRT_PORTID_USB               0x03            /**< USB */
-#define UBX_TX_CFG_PRT_PORTID_SPI               0x04            /**< SPI */
-#define UBX_TX_CFG_PRT_MODE                     0x000008D0      /**< 0b0000100011010000: 8N1 */
-#define UBX_TX_CFG_PRT_MODE_SPI                 0x00000100
-#define UBX_TX_CFG_PRT_BAUDRATE                 38400           /**< choose 38400 as GPS baudrate (pre M8* boards only) */
-#define UBX_TX_CFG_PRT_PROTO_UBX                (1<<0)
-#define UBX_TX_CFG_PRT_PROTO_RTCM               (1<<5)
+#define UBX_TX_CFG_PRT_PORTID		0x01		/**< UART1 */
+#define UBX_TX_CFG_PRT_PORTID_USB	0x03		/**< USB */
+#define UBX_TX_CFG_PRT_PORTID_SPI	0x04		/**< SPI */
+#define UBX_TX_CFG_PRT_MODE		0x000008D0	/**< 0b0000100011010000: 8N1 */
+#define UBX_TX_CFG_PRT_MODE_SPI	0x00000100
+#define UBX_TX_CFG_PRT_BAUDRATE		38400		/**< choose 38400 as GPS baudrate (pre M8* boards only) */
+#define UBX_TX_CFG_PRT_INPROTOMASK_GPS	((1<<5) | 0x01)	/**< RTCM3 in and UBX in */
+#define UBX_TX_CFG_PRT_INPROTOMASK_RTCM	(0x01)	/**< UBX in */
+#define UBX_TX_CFG_PRT_OUTPROTOMASK_GPS	(0x01)			/**< UBX out */
+#define UBX_TX_CFG_PRT_OUTPROTOMASK_RTCM	((1<<5) | 0x01)		/**< RTCM3 out and UBX out */
 
-#define UBX_BAUDRATE_M8_AND_NEWER               115200 /**< baudrate for M8+ boards */
+#define UBX_BAUDRATE_M8_AND_NEWER 115200 /**< baudrate for M8+ boards */
 
 /* TX CFG-RATE message contents
  * Note: not used with protocol version 27+ anymore
  */
-#define UBX_TX_CFG_RATE_MEASINTERVAL            200     /**< 200ms for 5Hz (F9* boards use 10Hz) */
-#define UBX_TX_CFG_RATE_NAVRATE                 1       /**< cannot be changed */
-#define UBX_TX_CFG_RATE_TIMEREF                 0       /**< 0: UTC, 1: GPS time */
+#define UBX_TX_CFG_RATE_MEASINTERVAL		200		/**< 200ms for 5Hz (F9* boards use 10Hz) */
+#define UBX_TX_CFG_RATE_NAVRATE		1		/**< cannot be changed */
+#define UBX_TX_CFG_RATE_TIMEREF		0		/**< 0: UTC, 1: GPS time */
 
 /* TX CFG-NAV5 message contents
  * Note: not used with protocol version 27+ anymore
  */
-#define UBX_TX_CFG_NAV5_MASK                    0x0005  /**< Only update dynamic model and fix mode */
-#define UBX_TX_CFG_NAV5_FIXMODE                 2       /**< 1 2D only, 2 3D only, 3 Auto 2D/3D */
+#define UBX_TX_CFG_NAV5_MASK		0x0005		/**< Only update dynamic model and fix mode */
+#define UBX_TX_CFG_NAV5_FIXMODE		2		/**< 1 2D only, 2 3D only, 3 Auto 2D/3D */
 
 /* TX CFG-RST message contents
  */
-#define UBX_TX_CFG_RST_BBR_MODE_HOT_START       0
-#define UBX_TX_CFG_RST_BBR_MODE_WARM_START      1
-#define UBX_TX_CFG_RST_BBR_MODE_COLD_START      0xFFFF
-#define UBX_TX_CFG_RST_MODE_HARDWARE            0
-#define UBX_TX_CFG_RST_MODE_SOFTWARE            1
-
-/* TX CFG-GNSS message contents
- */
-#define UBX_TX_CFG_GNSS_GNSSID_GPS              0       /**< gnssId of GPS */
-#define UBX_TX_CFG_GNSS_GNSSID_SBAS             1       /**< gnssId of SBAS */
-#define UBX_TX_CFG_GNSS_GNSSID_GALILEO          2       /**< gnssId of Galileo */
-#define UBX_TX_CFG_GNSS_GNSSID_BEIDOU           3       /**< gnssId of BeiDou */
-#define UBX_TX_CFG_GNSS_GNSSID_IMES             4       /**< gnssId of IMES */
-#define UBX_TX_CFG_GNSS_GNSSID_QZSS             5       /**< gnssId of QZSS */
-#define UBX_TX_CFG_GNSS_GNSSID_GLONASS          6       /**< gnssId of GLONASS */
-#define UBX_TX_CFG_GNSS_FLAGS_ENABLE            0x00000001  /**< Enable this GNSS system */
-#define UBX_TX_CFG_GNSS_FLAGS_GPS_L1CA          0x00010000  /**< GPS: Use L1C/A Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_GPS_L2C           0x00100000  /**< GPS: Use L2C Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_GPS_L5            0x00200000  /**< GPS: Use L5 Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_SBAS_L1CA         0x00010000  /**< SBAS: Use L1C/A Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_GALILEO_E1        0x00010000  /**< Galileo: Use E1 Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_GALILEO_E5A       0x00100000  /**< Galileo: Use E5a Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_GALILEO_E5B       0x00200000  /**< Galileo: Use E5b Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_BEIDOU_B1I        0x00010000  /**< BeiDou: Use B1I Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_BEIDOU_B2I        0x00100000  /**< BeiDou: Use B2I Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_BEIDOU_B2A        0x00800000  /**< BeiDou: Use B2A Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_IMES_L1           0x00010000  /**< IMES: Use L1 Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L1CA         0x00010000  /**< QZSS: Use L1C/A Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L1S          0x00040000  /**< QZSS: Use L1S Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L2C          0x00100000  /**< QZSS: Use L2C Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_QZSS_L5           0x00200000  /**< QZSS: Use L5 Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_GLONASS_L1        0x00010000  /**< GLONASS: Use L1 Signal */
-#define UBX_TX_CFG_GNSS_FLAGS_GLONASS_L2        0x00100000  /**< GLONASS: Use L2 Signal */
+#define UBX_TX_CFG_RST_BBR_MODE_HOT_START 	0
+#define UBX_TX_CFG_RST_BBR_MODE_WARM_START 	1
+#define UBX_TX_CFG_RST_BBR_MODE_COLD_START 	0xFFFF
+#define UBX_TX_CFG_RST_MODE_HARDWARE 		0
+#define UBX_TX_CFG_RST_MODE_SOFTWARE 		1
 
 /* Key ID's for CFG-VAL{GET,SET,DEL} */
-#define UBX_CFG_KEY_CFG_I2C_ENABLED             0x10510003
-#define UBX_CFG_KEY_CFG_I2CINPROT_UBX           0x10710001
-#define UBX_CFG_KEY_CFG_I2CINPROT_NMEA          0x10710002
-#define UBX_CFG_KEY_CFG_I2CINPROT_RTCM3X        0x10710004
-#define UBX_CFG_KEY_CFG_I2COUTPROT_UBX          0x10720001
-#define UBX_CFG_KEY_CFG_I2COUTPROT_NMEA         0x10720002
-#define UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X       0x10720004
+#define UBX_CFG_KEY_CFG_UART1_BAUDRATE           0x40520001
+#define UBX_CFG_KEY_CFG_UART1_STOPBITS           0x20520002
+#define UBX_CFG_KEY_CFG_UART1_DATABITS           0x20520003
+#define UBX_CFG_KEY_CFG_UART1_PARITY             0x20520004
+//#define UBX_CFG_KEY_CFG_UART1_ENABLED            0x20520005
+#define UBX_CFG_KEY_CFG_UART1_ENABLED            0x10520005
+//#define UBX_CFG_KEY_CFG_UART1_REMAP              0x20520006
+#define UBX_CFG_KEY_CFG_UART1INPROT_UBX          0x10730001
+#define UBX_CFG_KEY_CFG_UART1INPROT_NMEA         0x10730002
+//#define UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X       0x10730004
+#define UBX_CFG_KEY_CFG_UART1OUTPROT_UBX         0x10740001
+#define UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA        0x10740002
+//#define UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X      0x10740004
 
-#define UBX_CFG_KEY_CFG_UART1_BAUDRATE          0x40520001
-#define UBX_CFG_KEY_CFG_UART1_STOPBITS          0x20520002
-#define UBX_CFG_KEY_CFG_UART1_DATABITS          0x20520003
-#define UBX_CFG_KEY_CFG_UART1_PARITY            0x20520004
-#define UBX_CFG_KEY_CFG_UART1_ENABLED           0x20520005
-#define UBX_CFG_KEY_CFG_UART1_REMAP             0x20520006
-#define UBX_CFG_KEY_CFG_UART1INPROT_UBX         0x10730001
-#define UBX_CFG_KEY_CFG_UART1INPROT_NMEA        0x10730002
-#define UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X      0x10730004
-#define UBX_CFG_KEY_CFG_UART1OUTPROT_UBX        0x10740001
-#define UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA       0x10740002
-#define UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X     0x10740004
+#define UBX_CFG_KEY_CFG_UART2_BAUDRATE           0x40530001
+#define UBX_CFG_KEY_CFG_UART2_STOPBITS           0x20530002
+#define UBX_CFG_KEY_CFG_UART2_DATABITS           0x20530003
+#define UBX_CFG_KEY_CFG_UART2_PARITY             0x20530004
+#define UBX_CFG_KEY_CFG_UART2_ENABLED            0x20530005
+#define UBX_CFG_KEY_CFG_UART2_REMAP              0x20530006
+#define UBX_CFG_KEY_CFG_UART2INPROT_UBX          0x10750001
+#define UBX_CFG_KEY_CFG_UART2INPROT_NMEA         0x10750002
+#define UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X       0x10750004
+#define UBX_CFG_KEY_CFG_UART2OUTPROT_UBX         0x10760001
+#define UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA        0x10760002
+#define UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X      0x10760004
 
-#define UBX_CFG_KEY_CFG_UART2_BAUDRATE          0x40530001
-#define UBX_CFG_KEY_CFG_UART2_STOPBITS          0x20530002
-#define UBX_CFG_KEY_CFG_UART2_DATABITS          0x20530003
-#define UBX_CFG_KEY_CFG_UART2_PARITY            0x20530004
-#define UBX_CFG_KEY_CFG_UART2_ENABLED           0x20530005
-#define UBX_CFG_KEY_CFG_UART2_REMAP             0x20530006
-#define UBX_CFG_KEY_CFG_UART2INPROT_UBX         0x10750001
-#define UBX_CFG_KEY_CFG_UART2INPROT_NMEA        0x10750002
-#define UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X      0x10750004
-#define UBX_CFG_KEY_CFG_UART2OUTPROT_UBX        0x10760001
-#define UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA       0x10760002
-#define UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X     0x10760004
+#define UBX_CFG_KEY_CFG_USB_ENABLED              0x10650001
+#define UBX_CFG_KEY_CFG_USBINPROT_UBX            0x10770001
+#define UBX_CFG_KEY_CFG_USBINPROT_NMEA           0x10770002
+#define UBX_CFG_KEY_CFG_USBINPROT_RTCM3X         0x10770004
+#define UBX_CFG_KEY_CFG_USBOUTPROT_UBX           0x10780001
+#define UBX_CFG_KEY_CFG_USBOUTPROT_NMEA          0x10780002
+#define UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X        0x10780004
 
-#define UBX_CFG_KEY_CFG_USB_ENABLED             0x10650001
-#define UBX_CFG_KEY_CFG_USBINPROT_UBX           0x10770001
-#define UBX_CFG_KEY_CFG_USBINPROT_NMEA          0x10770002
-#define UBX_CFG_KEY_CFG_USBINPROT_RTCM3X        0x10770004
-#define UBX_CFG_KEY_CFG_USBOUTPROT_UBX          0x10780001
-#define UBX_CFG_KEY_CFG_USBOUTPROT_NMEA         0x10780002
-#define UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X       0x10780004
+#define UBX_CFG_KEY_CFG_SPIINPROT_UBX            0x10790001
+#define UBX_CFG_KEY_CFG_SPIINPROT_NMEA           0x10790002
+#define UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X         0x10790004
+#define UBX_CFG_KEY_CFG_SPIOUTPROT_UBX           0x107a0001
+#define UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA          0x107a0002
+#define UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X        0x107a0004
 
-#define UBX_CFG_KEY_CFG_SPIINPROT_UBX           0x10790001
-#define UBX_CFG_KEY_CFG_SPIINPROT_NMEA          0x10790002
-#define UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X        0x10790004
-#define UBX_CFG_KEY_CFG_SPIOUTPROT_UBX          0x107a0001
-#define UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA         0x107a0002
-#define UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X       0x107a0004
+#define UBX_CFG_KEY_NAVHPG_DGNSSMODE             0x20140011
 
-#define UBX_CFG_KEY_NAVHPG_DGNSSMODE            0x20140011
+#define UBX_CFG_KEY_NAVSPG_FIXMODE               0x20110011
+#define UBX_CFG_KEY_NAVSPG_UTCSTANDARD           0x2011001c
+#define UBX_CFG_KEY_NAVSPG_DYNMODEL              0x20110021
 
-#define UBX_CFG_KEY_NAVSPG_FIXMODE              0x20110011
-#define UBX_CFG_KEY_NAVSPG_UTCSTANDARD          0x2011001c
-#define UBX_CFG_KEY_NAVSPG_DYNMODEL             0x20110021
+#define UBX_CFG_KEY_ODO_USE_ODO                  0x10220001
+#define UBX_CFG_KEY_ODO_USE_COG                  0x10220002
+#define UBX_CFG_KEY_ODO_OUTLPVEL                 0x10220003
+#define UBX_CFG_KEY_ODO_OUTLPCOG                 0x10220004
 
-#define UBX_CFG_KEY_ODO_USE_ODO                 0x10220001
-#define UBX_CFG_KEY_ODO_USE_COG                 0x10220002
-#define UBX_CFG_KEY_ODO_OUTLPVEL                0x10220003
-#define UBX_CFG_KEY_ODO_OUTLPCOG                0x10220004
+#define UBX_CFG_KEY_RATE_MEAS                    0x30210001
+#define UBX_CFG_KEY_RATE_NAV                     0x30210002
+#define UBX_CFG_KEY_RATE_TIMEREF                 0x20210003
 
-#define UBX_CFG_KEY_ITFM_ENABLE                 0x1041000d
+#define UBX_CFG_KEY_TMODE_MODE                   0x20030001
+#define UBX_CFG_KEY_TMODE_POS_TYPE               0x20030002
+#define UBX_CFG_KEY_TMODE_LAT                    0x40030009
+#define UBX_CFG_KEY_TMODE_LON                    0x4003000a
+#define UBX_CFG_KEY_TMODE_HEIGHT                 0x4003000b
+#define UBX_CFG_KEY_TMODE_LAT_HP                 0x2003000c
+#define UBX_CFG_KEY_TMODE_LON_HP                 0x2003000d
+#define UBX_CFG_KEY_TMODE_HEIGHT_HP              0x2003000e
+#define UBX_CFG_KEY_TMODE_FIXED_POS_ACC          0x4003000f
+#define UBX_CFG_KEY_TMODE_SVIN_MIN_DUR           0x40030010
+#define UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT         0x40030011
 
-#define UBX_CFG_KEY_RATE_MEAS                   0x30210001
-#define UBX_CFG_KEY_RATE_NAV                    0x30210002
-#define UBX_CFG_KEY_RATE_TIMEREF                0x20210003
+#define UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C        0x20910359
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C      0x20910088 /**< deprecased in protover 34. Use UBX-NAV-SAT or UBX-NAV-SIG instead */
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SIG_I2C	 0x20910345
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C       0x20910015
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C       0x20910038
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C       0x20910006
 
-#define UBX_CFG_KEY_TMODE_MODE                  0x20030001
-#define UBX_CFG_KEY_TMODE_POS_TYPE              0x20030002
-#define UBX_CFG_KEY_TMODE_LAT                   0x40030009
-#define UBX_CFG_KEY_TMODE_LON                   0x4003000a
-#define UBX_CFG_KEY_TMODE_HEIGHT                0x4003000b
-#define UBX_CFG_KEY_TMODE_LAT_HP                0x2003000c
-#define UBX_CFG_KEY_TMODE_LON_HP                0x2003000d
-#define UBX_CFG_KEY_TMODE_HEIGHT_HP             0x2003000e
-#define UBX_CFG_KEY_TMODE_FIXED_POS_ACC         0x4003000f
-#define UBX_CFG_KEY_TMODE_SVIN_MIN_DUR          0x40030010
-#define UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT        0x40030011
+#define UBX_CFG_KEY_MSGOUT_UBX_MON_RF_UART1        0x2091035a
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_UART1      0x20910088 /**< deprecased in protover 34. Use UBX-NAV-SAT or UBX-NAV-SIG instead */
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SIG_UART1	 0x20910346
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_UART1	   0x20910016
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_UART1       0x20910039
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_UART1       0x20910007
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_VELNED_UART1       0x20910043
 
-#define UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C       0x20910359
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C     0x20910088
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C      0x20910015
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C      0x20910038
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C      0x20910006
-#define UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C 0x2091008d
-#define UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C    0x20910231
-#define UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C     0x209102a4
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C 0x209102bd
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C 0x209102cc
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C 0x209102d1
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C 0x20910318
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C 0x209102d6
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C 0x20910303
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C  0x209102bd
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C  0x209102cc
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C  0x209102d1
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C  0x20910318
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C  0x209102d6
+#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C  0x20910303
 
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2  0x20910300
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_1_UART2  0x20910383
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2    0x209102ce
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2    0x209102d3
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2    0x2091031a
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2    0x209102d8
-#define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART2    0x20910305
+#define UBX_CFG_KEY_SPI_ENABLED                  0x10640006
+#define UBX_CFG_KEY_SPI_MAXFF                    0x20640001
 
-#define UBX_CFG_KEY_SPI_ENABLED                 0x10640006
-#define UBX_CFG_KEY_SPI_MAXFF                   0x20640001
+#define UBX_CFG_KEY_HW_RF_LNA_MODE		 0x20a30057
 
-#define UBX_CFG_KEY_SIGNAL_GPS_ENA              0x1031001f  /**< GPS enable */
-#define UBX_CFG_KEY_SIGNAL_GPS_L1CA_ENA         0x10310001  /**< GPS L1C/A */
-#define UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA          0x10310003  /**< GPS L2C (only on u-blox F9 platform products) */
-#define UBX_CFG_KEY_SIGNAL_SBAS_ENA             0x10310020  /**< SBAS enable */
-#define UBX_CFG_KEY_SIGNAL_SBAS_L1CA_ENA        0x10310005  /**< SBAS L1C/A */
-#define UBX_CFG_KEY_SIGNAL_GAL_ENA              0x10310021  /**< Galileo enable */
-#define UBX_CFG_KEY_SIGNAL_GAL_E1_ENA           0x10310007  /**< Galileo E1 */
-#define UBX_CFG_KEY_SIGNAL_GAL_E5B_ENA          0x1031000a  /**< Galileo E5b (only on u-blox F9 platform products) */
-#define UBX_CFG_KEY_SIGNAL_BDS_ENA              0x10310022  /**< BeiDou Enable */
-#define UBX_CFG_KEY_SIGNAL_BDS_B1_ENA           0x1031000d  /**< BeiDou B1I */
-#define UBX_CFG_KEY_SIGNAL_BDS_B2_ENA           0x1031000e  /**< BeiDou B2I (only on u-blox F9 platform products) */
-#define UBX_CFG_KEY_SIGNAL_QZSS_ENA             0x10310024  /**< QZSS enable */
-#define UBX_CFG_KEY_SIGNAL_QZSS_L1CA_ENA        0x10310012  /**< QZSS L1C/A */
-#define UBX_CFG_KEY_SIGNAL_QZSS_L1S_ENA         0x10310014  /**< QZSS L1S */
-#define UBX_CFG_KEY_SIGNAL_QZSS_L2C_ENA         0x10310015  /**< QZSS L2C (only on u-blox F9 platform products) */
-#define UBX_CFG_KEY_SIGNAL_GLO_ENA              0x10310025  /**< GLONASS enable */
-#define UBX_CFG_KEY_SIGNAL_GLO_L1_ENA           0x10310018  /**< GLONASS L1 */
-#define UBX_CFG_KEY_SIGNAL_GLO_L2_ENA           0x1031001a  /**< GLONASS L2 (only on u-blox F9 platform products) */
+#define UBX_CFG_KEY_ITFM_ANTSETTING		 0x20410010
 
-#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX7        (sizeof(ubx_payload_rx_nav_pvt_t) - 8)
-#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX8        (sizeof(ubx_payload_rx_nav_pvt_t))
+#define UBX_CFG_SIGNAL_GPS_ENA			0x1031001f
+#define UBX_CFG_SIGNAL_GPS_L1CA_ENA		0x10310001
+#define UBX_CFG_SIGNAL_SBAS_ENA			0x10310020
+#define UBX_CFG_SIGNAL_SBAS_L1CA_ENA		0x10310005
+#define UBX_CFG_SIGNAL_GAL_ENA			0x10310021
+#define UBX_CFG_SIGNAL_GAL_El_ENA		0x10310007
+#define UBX_CFG_SIGNAL_BDS_ENA			0x10310022
+#define UBX_CFG_SIGNAL_BDS_B1_ENA		0x1031000d
+#define UBX_CFG_SIGNAL_QZSS_ENA			0x10310024
+#define UBX_CFG_SIGNAL_QZSS_L1CA_ENA		0x10310012
+#define UBX_CFG_SIGNAL_GLO_ENA			0x10310025
+#define UBX_CFG_SIGNAL_GLO_L1_ENA		0x10310018
 
-#define UBX_CFG_LAYER_RAM                       (1 << 0)
-#define UBX_CFG_LAYER_BBR                       (1 << 1)
-#define UBX_CFG_LAYER_FLASH                     (1 << 2)
 
-// Forward Declaration
+
 class RTCMParsing;
 
 
@@ -394,224 +337,226 @@ class RTCMParsing;
 
 /* General: Header */
 typedef struct {
-	uint8_t  sync1;
-	uint8_t  sync2;
-	uint16_t msg;
-	uint16_t length;
+	uint8_t		sync1;
+	uint8_t		sync2;
+	uint16_t	msg;
+	uint16_t	length;
 } ubx_header_t;
 
 /* General: Checksum */
 typedef struct {
-	uint8_t ck_a;
-	uint8_t ck_b;
+	uint8_t		ck_a;
+	uint8_t		ck_b;
 } ubx_checksum_t ;
 
 /* Rx NAV-POSLLH */
 typedef struct {
-	uint32_t iTOW;   /**< GPS Time of Week [ms] */
-	int32_t  lon;    /**< Longitude [1e-7 deg] */
-	int32_t  lat;    /**< Latitude [1e-7 deg] */
-	int32_t  height; /**< Height above ellipsoid [mm] */
-	int32_t  hMSL;   /**< Height above mean sea level [mm] */
-	uint32_t hAcc;   /**< Horizontal accuracy estimate [mm] */
-	uint32_t vAcc;   /**< Vertical accuracy estimate [mm] */
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	int32_t		lon;		/**< Longitude [1e-7 deg] */
+	int32_t		lat;		/**< Latitude [1e-7 deg] */
+	int32_t		height;		/**< Height above ellipsoid [mm] */
+	int32_t		hMSL;		/**< Height above mean sea level [mm] */
+	uint32_t	hAcc;  		/**< Horizontal accuracy estimate [mm] */
+	uint32_t	vAcc;  		/**< Vertical accuracy estimate [mm] */
 } ubx_payload_rx_nav_posllh_t;
 
 /* Rx NAV-DOP */
 typedef struct {
-	uint32_t iTOW; /**< GPS Time of Week [ms] */
-	uint16_t gDOP; /**< Geometric DOP [0.01] */
-	uint16_t pDOP; /**< Position DOP [0.01] */
-	uint16_t tDOP; /**< Time DOP [0.01] */
-	uint16_t vDOP; /**< Vertical DOP [0.01] */
-	uint16_t hDOP; /**< Horizontal DOP [0.01] */
-	uint16_t nDOP; /**< Northing DOP [0.01] */
-	uint16_t eDOP; /**< Easting DOP [0.01] */
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	uint16_t	gDOP;		/**< Geometric DOP [0.01] */
+	uint16_t	pDOP;		/**< Position DOP [0.01] */
+	uint16_t	tDOP;		/**< Time DOP [0.01] */
+	uint16_t	vDOP;		/**< Vertical DOP [0.01] */
+	uint16_t	hDOP;		/**< Horizontal DOP [0.01] */
+	uint16_t	nDOP;		/**< Northing DOP [0.01] */
+	uint16_t	eDOP;		/**< Easting DOP [0.01] */
 } ubx_payload_rx_nav_dop_t;
 
 /* Rx NAV-SOL */
 typedef struct {
-	uint32_t iTOW;     /**< GPS Time of Week [ms] */
-	int32_t  fTOW;     /**< Fractional part of iTOW (range: +/-500000) [ns] */
-	int16_t  week;     /**< GPS week */
-	uint8_t  gpsFix;   /**< GPSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GPS + dead reckoning, 5 = time only fix */
-	uint8_t  flags;
-	int32_t  ecefX;
-	int32_t  ecefY;
-	int32_t  ecefZ;
-	uint32_t pAcc;
-	int32_t  ecefVX;
-	int32_t  ecefVY;
-	int32_t  ecefVZ;
-	uint32_t sAcc;
-	uint16_t pDOP;      /**< Position DOP [0.01] */
-	uint8_t  reserved1;
-	uint8_t  numSV;     /**< Number of SVs used in Nav Solution */
-	uint32_t reserved2;
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	int32_t		fTOW;		/**< Fractional part of iTOW (range: +/-500000) [ns] */
+	int16_t		week;		/**< GPS week */
+	uint8_t		gpsFix;		/**< GPSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GPS + dead reckoning, 5 = time only fix */
+	uint8_t		flags;
+	int32_t		ecefX;
+	int32_t		ecefY;
+	int32_t		ecefZ;
+	uint32_t	pAcc;
+	int32_t		ecefVX;
+	int32_t		ecefVY;
+	int32_t		ecefVZ;
+	uint32_t	sAcc;
+	uint16_t	pDOP;		/**< Position DOP [0.01] */
+	uint8_t		reserved1;
+	uint8_t		numSV;		/**< Number of SVs used in Nav Solution */
+	uint32_t	reserved2;
 } ubx_payload_rx_nav_sol_t;
 
 /* Rx NAV-PVT (ubx8) */
 typedef struct {
-	uint32_t iTOW;          /**< GPS Time of Week [ms] */
-	uint16_t year;          /**< Year (UTC)*/
-	uint8_t  month;         /**< Month, range 1..12 (UTC) */
-	uint8_t  day;           /**< Day of month, range 1..31 (UTC) */
-	uint8_t  hour;          /**< Hour of day, range 0..23 (UTC) */
-	uint8_t  min;           /**< Minute of hour, range 0..59 (UTC) */
-	uint8_t  sec;           /**< Seconds of minute, range 0..60 (UTC) */
-	uint8_t  valid;         /**< Validity flags (see UBX_RX_NAV_PVT_VALID_...) */
-	uint32_t tAcc;          /**< Time accuracy estimate (UTC) [ns] */
-	int32_t  nano;          /**< Fraction of second (UTC) [-1e9...1e9 ns] */
-	uint8_t  fixType;       /**< GNSSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GNSS + dead reckoning, 5 = time only fix */
-	uint8_t  flags;         /**< Fix Status Flags (see UBX_RX_NAV_PVT_FLAGS_...) */
-	uint8_t  reserved1;
-	uint8_t  numSV;         /**< Number of SVs used in Nav Solution */
-	int32_t  lon;           /**< Longitude [1e-7 deg] */
-	int32_t  lat;           /**< Latitude [1e-7 deg] */
-	int32_t  height;        /**< Height above ellipsoid [mm] */
-	int32_t  hMSL;          /**< Height above mean sea level [mm] */
-	uint32_t hAcc;          /**< Horizontal accuracy estimate [mm] */
-	uint32_t vAcc;          /**< Vertical accuracy estimate [mm] */
-	int32_t  velN;          /**< NED north velocity [mm/s]*/
-	int32_t  velE;          /**< NED east velocity [mm/s]*/
-	int32_t  velD;          /**< NED down velocity [mm/s]*/
-	int32_t  gSpeed;        /**< Ground Speed (2-D) [mm/s] */
-	int32_t  headMot;       /**< Heading of motion (2-D) [1e-5 deg] */
-	uint32_t sAcc;          /**< Speed accuracy estimate [mm/s] */
-	uint32_t headAcc;       /**< Heading accuracy estimate (motion and vehicle) [1e-5 deg] */
-	uint16_t pDOP;          /**< Position DOP [0.01] */
-	uint16_t reserved2;
-	uint32_t reserved3;
-	int32_t  headVeh;       /**< (ubx8+ only) Heading of vehicle (2-D) [1e-5 deg] */
-	uint32_t reserved4;     /**< (ubx8+ only) */
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	uint16_t	year; 		/**< Year (UTC)*/
+	uint8_t		month; 		/**< Month, range 1..12 (UTC) */
+	uint8_t		day; 		/**< Day of month, range 1..31 (UTC) */
+	uint8_t		hour; 		/**< Hour of day, range 0..23 (UTC) */
+	uint8_t		min; 		/**< Minute of hour, range 0..59 (UTC) */
+	uint8_t		sec;		/**< Seconds of minute, range 0..60 (UTC) */
+	uint8_t		valid; 		/**< Validity flags (see UBX_RX_NAV_PVT_VALID_...) */
+	uint32_t	tAcc; 		/**< Time accuracy estimate (UTC) [ns] */
+	int32_t		nano;		/**< Fraction of second (UTC) [-1e9...1e9 ns] */
+	uint8_t		fixType;	/**< GNSSfix type: 0 = No fix, 1 = Dead Reckoning only, 2 = 2D fix, 3 = 3d-fix, 4 = GNSS + dead reckoning, 5 = time only fix */
+	uint8_t		flags;		/**< Fix Status Flags (see UBX_RX_NAV_PVT_FLAGS_...) */
+	uint8_t		reserved1;
+	uint8_t		numSV;		/**< Number of SVs used in Nav Solution */
+	int32_t		lon;		/**< Longitude [1e-7 deg] */
+	int32_t		lat;		/**< Latitude [1e-7 deg] */
+	int32_t		height;		/**< Height above ellipsoid [mm] */
+	int32_t		hMSL;		/**< Height above mean sea level [mm] */
+	uint32_t	hAcc;  		/**< Horizontal accuracy estimate [mm] */
+	uint32_t	vAcc;  		/**< Vertical accuracy estimate [mm] */
+	int32_t		velN;		/**< NED north velocity [mm/s]*/
+	int32_t		velE;		/**< NED east velocity [mm/s]*/
+	int32_t		velD;		/**< NED down velocity [mm/s]*/
+	int32_t		gSpeed;		/**< Ground Speed (2-D) [mm/s] */
+	int32_t		headMot;	/**< Heading of motion (2-D) [1e-5 deg] */
+	uint32_t	sAcc;		/**< Speed accuracy estimate [mm/s] */
+	uint32_t	headAcc;	/**< Heading accuracy estimate (motion and vehicle) [1e-5 deg] */
+	uint16_t	pDOP;		/**< Position DOP [0.01] */
+	uint16_t	reserved2;
+	uint32_t	reserved3;
+	int32_t		headVeh;	/**< (ubx8+ only) Heading of vehicle (2-D) [1e-5 deg] */
+	uint32_t	reserved4;	/**< (ubx8+ only) */
 } ubx_payload_rx_nav_pvt_t;
+#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX7	(sizeof(ubx_payload_rx_nav_pvt_t) - 8)
+#define UBX_PAYLOAD_RX_NAV_PVT_SIZE_UBX8	(sizeof(ubx_payload_rx_nav_pvt_t))
 
 /* Rx NAV-TIMEUTC */
 typedef struct {
-	uint32_t iTOW;           /**< GPS Time of Week [ms] */
-	uint32_t tAcc;           /**< Time accuracy estimate (UTC) [ns] */
-	int32_t  nano;           /**< Fraction of second, range -1e9 .. 1e9 (UTC) [ns] */
-	uint16_t year;           /**< Year, range 1999..2099 (UTC) */
-	uint8_t  month;          /**< Month, range 1..12 (UTC) */
-	uint8_t  day;            /**< Day of month, range 1..31 (UTC) */
-	uint8_t  hour;           /**< Hour of day, range 0..23 (UTC) */
-	uint8_t  min;            /**< Minute of hour, range 0..59 (UTC) */
-	uint8_t  sec;            /**< Seconds of minute, range 0..60 (UTC) */
-	uint8_t  valid;          /**< Validity Flags (see UBX_RX_NAV_TIMEUTC_VALID_...) */
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	uint32_t	tAcc; 		/**< Time accuracy estimate (UTC) [ns] */
+	int32_t		nano;		/**< Fraction of second, range -1e9 .. 1e9 (UTC) [ns] */
+	uint16_t	year; 		/**< Year, range 1999..2099 (UTC) */
+	uint8_t		month; 		/**< Month, range 1..12 (UTC) */
+	uint8_t		day; 		/**< Day of month, range 1..31 (UTC) */
+	uint8_t		hour; 		/**< Hour of day, range 0..23 (UTC) */
+	uint8_t		min; 		/**< Minute of hour, range 0..59 (UTC) */
+	uint8_t		sec;		/**< Seconds of minute, range 0..60 (UTC) */
+	uint8_t		valid; 		/**< Validity Flags (see UBX_RX_NAV_TIMEUTC_VALID_...) */
 } ubx_payload_rx_nav_timeutc_t;
 
 /* Rx NAV-SVINFO Part 1 */
 typedef struct {
-	uint32_t iTOW;           /**< GPS Time of Week [ms] */
-	uint8_t  numCh;          /**< Number of channels */
-	uint8_t  globalFlags;
-	uint16_t reserved2;
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	uint8_t		numCh; 		/**< Number of channels */
+	uint8_t		globalFlags;
+	uint16_t	reserved2;
 } ubx_payload_rx_nav_svinfo_part1_t;
 
 /* Rx NAV-SVINFO Part 2 (repeated) */
 typedef struct {
-	uint8_t chn;            /**< Channel number, 255 for SVs not assigned to a channel */
-	uint8_t svid;           /**< Satellite ID */
-	uint8_t flags;          /**< svUsed, diffCorr, orbitAvail, orbitEph, unhealthy, orbitAlm, orbitAop, smoothed */
-	uint8_t quality;        /**< 0: no signal, 1: search, 2: aquited, 3: unusable, 5-7: locked */
-	uint8_t cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	int8_t  elev;           /**< Elevation [deg] */
-	int16_t azim;           /**< Azimuth [deg] */
-	int32_t prRes;          /**< Pseudo range residual [cm] */
+	uint8_t		chn; 		/**< Channel number, 255 for SVs not assigned to a channel */
+	uint8_t		svid; 		/**< Satellite ID */
+	uint8_t		flags;
+	uint8_t		quality;
+	uint8_t		cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+	int8_t		elev; 		/**< Elevation [deg] */
+	int16_t		azim; 		/**< Azimuth [deg] */
+	int32_t		prRes; 		/**< Pseudo range residual [cm] */
 } ubx_payload_rx_nav_svinfo_part2_t;
 
 /* Rx NAV-SAT Part 1 */
 typedef struct {
-	uint32_t iTOW;           /**< GPS Time of Week [ms] */
-	uint8_t  version;        /**< Message version (1) */
-	uint8_t  numSvs;         /**< Number of Satellites */
-	uint16_t reserved;
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	uint8_t		version; 	/**< Message version (1) */
+	uint8_t		numSvs;		/**< Number of Satellites */
+	uint16_t	reserved;
 } ubx_payload_rx_nav_sat_part1_t;
 
 /* Rx NAV-SAT Part 2 (repeated) */
 typedef struct {
-	uint8_t  gnssId;         /**< GNSS identifier */
-	uint8_t  svId;           /**< Satellite ID */
-	uint8_t  cno;            /**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
-	int8_t   elev;           /**< Elevation [deg] range: +/-90 */
-	int16_t  azim;           /**< Azimuth [deg] range: 0-360 */
-	int16_t  prRes;          /**< Pseudo range residual [0.1 m] */
-	uint32_t flags;
+	uint8_t		gnssId;		/**< GNSS identifier */
+	uint8_t		svId; 		/**< Satellite ID */
+	uint8_t		cno;		/**< Carrier to Noise Ratio (Signal Strength) [dbHz] */
+	int8_t		elev; 		/**< Elevation [deg] range: +/-90 */
+	int16_t		azim; 		/**< Azimuth [deg] range: 0-360 */
+	int16_t		prRes; 		/**< Pseudo range residual [0.1 m] */
+	uint32_t	flags;
 } ubx_payload_rx_nav_sat_part2_t;
 
 /* Rx NAV-SVIN (survey-in info) */
 typedef struct {
-	uint8_t  version;
-	uint8_t  reserved1[3];
-	uint32_t iTOW;
-	uint32_t dur;
-	int32_t  meanX;
-	int32_t  meanY;
-	int32_t  meanZ;
-	int8_t   meanXHP;
-	int8_t   meanYHP;
-	int8_t   meanZHP;
-	int8_t   reserved2;
-	uint32_t meanAcc;
-	uint32_t obs;
-	uint8_t  valid;
-	uint8_t  active;
-	uint8_t  reserved3[2];
+	uint8_t     version;
+	uint8_t     reserved1[3];
+	uint32_t	iTOW;
+	uint32_t    dur;
+	int32_t     meanX;
+	int32_t     meanY;
+	int32_t     meanZ;
+	int8_t      meanXHP;
+	int8_t      meanYHP;
+	int8_t      meanZHP;
+	int8_t      reserved2;
+	uint32_t    meanAcc;
+	uint32_t    obs;
+	uint8_t     valid;
+	uint8_t     active;
+	uint8_t     reserved3[2];
 } ubx_payload_rx_nav_svin_t;
 
 /* Rx NAV-VELNED */
 typedef struct {
-	uint32_t iTOW;           /**< GPS Time of Week [ms] */
-	int32_t  velN;           /**< North velocity component [cm/s]*/
-	int32_t  velE;           /**< East velocity component [cm/s]*/
-	int32_t  velD;           /**< Down velocity component [cm/s]*/
-	uint32_t speed;          /**< Speed (3-D) [cm/s] */
-	uint32_t gSpeed;         /**< Ground speed (2-D) [cm/s] */
-	int32_t  heading;        /**< Heading of motion 2-D [1e-5 deg] */
-	uint32_t sAcc;           /**< Speed accuracy estimate [cm/s] */
-	uint32_t cAcc;           /**< Course / Heading accuracy estimate [1e-5 deg] */
+	uint32_t	iTOW;		/**< GPS Time of Week [ms] */
+	int32_t		velN;		/**< North velocity component [cm/s]*/
+	int32_t		velE;		/**< East velocity component [cm/s]*/
+	int32_t		velD;		/**< Down velocity component [cm/s]*/
+	uint32_t	speed;		/**< Speed (3-D) [cm/s] */
+	uint32_t	gSpeed;		/**< Ground speed (2-D) [cm/s] */
+	int32_t		heading;	/**< Heading of motion 2-D [1e-5 deg] */
+	uint32_t	sAcc;		/**< Speed accuracy estimate [cm/s] */
+	uint32_t	cAcc;		/**< Course / Heading accuracy estimate [1e-5 deg] */
 } ubx_payload_rx_nav_velned_t;
 
 /* Rx MON-HW (ubx6) */
 typedef struct {
-	uint32_t pinSel;
-	uint32_t pinBank;
-	uint32_t pinDir;
-	uint32_t pinVal;
-	uint16_t noisePerMS;
-	uint16_t agcCnt;
-	uint8_t  aStatus;
-	uint8_t  aPower;
-	uint8_t  flags;
-	uint8_t  reserved1;
-	uint32_t usedMask;
-	uint8_t  VP[25];
-	uint8_t  jamInd;
-	uint16_t reserved3;
-	uint32_t pinIrq;
-	uint32_t pullH;
-	uint32_t pullL;
+	uint32_t	pinSel;
+	uint32_t	pinBank;
+	uint32_t	pinDir;
+	uint32_t	pinVal;
+	uint16_t	noisePerMS;
+	uint16_t	agcCnt;
+	uint8_t		aStatus;
+	uint8_t		aPower;
+	uint8_t		flags;
+	uint8_t		reserved1;
+	uint32_t	usedMask;
+	uint8_t		VP[25];
+	uint8_t		jamInd;
+	uint16_t	reserved3;
+	uint32_t	pinIrq;
+	uint32_t	pullH;
+	uint32_t	pullL;
 } ubx_payload_rx_mon_hw_ubx6_t;
 
 /* Rx MON-HW (ubx7+) */
 typedef struct {
-	uint32_t pinSel;
-	uint32_t pinBank;
-	uint32_t pinDir;
-	uint32_t pinVal;
-	uint16_t noisePerMS;
-	uint16_t agcCnt;
-	uint8_t  aStatus;
-	uint8_t  aPower;
-	uint8_t  flags;
-	uint8_t  reserved1;
-	uint32_t usedMask;
-	uint8_t  VP[17];
-	uint8_t  jamInd;
-	uint16_t reserved3;
-	uint32_t pinIrq;
-	uint32_t pullH;
-	uint32_t pullL;
+	uint32_t	pinSel;
+	uint32_t	pinBank;
+	uint32_t	pinDir;
+	uint32_t	pinVal;
+	uint16_t	noisePerMS;
+	uint16_t	agcCnt;
+	uint8_t		aStatus;
+	uint8_t		aPower;
+	uint8_t		flags;
+	uint8_t		reserved1;
+	uint32_t	usedMask;
+	uint8_t		VP[17];
+	uint8_t		jamInd;
+	uint16_t	reserved3;
+	uint32_t	pinIrq;
+	uint32_t	pullH;
+	uint32_t	pullL;
 } ubx_payload_rx_mon_hw_ubx7_t;
 
 /* Rx MON-RF (replaces MON-HW, protocol 27+) */
@@ -621,20 +566,20 @@ typedef struct {
 	uint8_t reserved1[2];
 
 	struct ubx_payload_rx_mon_rf_block_t {
-		uint8_t  blockId;       /**< RF block id */
-		uint8_t  flags;         /**< jammingState */
-		uint8_t  antStatus;     /**< Status of the antenna superior state machine */
-		uint8_t  antPower;      /**< Current power status of antenna */
-		uint32_t postStatus;    /**< POST status word */
-		uint8_t  reserved2[4];
-		uint16_t noisePerMS;    /**< Noise level as measured by the GPS core */
-		uint16_t agcCnt;        /**< AGC Monitor (counts SIGI xor SIGLO, range 0 to 8191 */
-		uint8_t  jamInd;        /**< CW jamming indicator, scaled (0=no CW jamming, 255=strong CW jamming) */
-		int8_t   ofsI;          /**< Imbalance of I-part of complex signal */
-		uint8_t  magI;          /**< Magnitude of I-part of complex signal (0=no signal, 255=max magnitude) */
-		int8_t   ofsQ;          /**< Imbalance of Q-part of complex signal */
-		uint8_t  magQ;          /**< Magnitude of Q-part of complex signal (0=no signal, 255=max magnitude) */
-		uint8_t  reserved3[3];
+		uint8_t blockId;     /**< RF block id */
+		uint8_t flags;       /**< jammingState */
+		uint8_t antStatus;   /**< Status of the antenna superior state machine */
+		uint8_t antPower;    /**< Current power status of antenna */
+		uint32_t postStatus; /**< POST status word */
+		uint8_t reserved2[4];
+		uint16_t noisePerMS; /**< Noise level as measured by the GPS core */
+		uint16_t agcCnt;     /**< AGC Monitor (counts SIGI xor SIGLO, range 0 to 8191 */
+		uint8_t jamInd;      /**< CW jamming indicator, scaled (0=no CW jamming, 255=strong CW jamming) */
+		int8_t ofsI;         /**< Imbalance of I-part of complex signal */
+		uint8_t magI;        /**< Magnitude of I-part of complex signal (0=no signal, 255=max magnitude) */
+		int8_t ofsQ;         /**< Imbalance of Q-part of complex signal */
+		uint8_t magQ;        /**< Magnitude of Q-part of complex signal (0=no signal, 255=max magnitude) */
+		uint8_t reserved3[3];
 	};
 
 	ubx_payload_rx_mon_rf_block_t block[1]; ///< only read out the first block
@@ -642,116 +587,120 @@ typedef struct {
 
 /* Rx MON-VER Part 1 */
 typedef struct {
-	uint8_t swVersion[30];
-	uint8_t hwVersion[10];
+	uint8_t		swVersion[30];
+	uint8_t		hwVersion[10];
 } ubx_payload_rx_mon_ver_part1_t;
 
 /* Rx MON-VER Part 2 (repeated) */
 typedef struct {
-	uint8_t extension[30];
+	uint8_t		extension[30];
 } ubx_payload_rx_mon_ver_part2_t;
 
 /* Rx ACK-ACK */
-typedef union {
-	uint16_t msg;
+typedef	union {
+	uint16_t	msg;
 	struct {
-		uint8_t clsID;
-		uint8_t msgID;
+		uint8_t	clsID;
+		uint8_t	msgID;
 	};
 } ubx_payload_rx_ack_ack_t;
 
 /* Rx ACK-NAK */
-typedef union {
-	uint16_t msg;
+typedef	union {
+	uint16_t	msg;
 	struct {
-		uint8_t clsID;
-		uint8_t msgID;
+		uint8_t	clsID;
+		uint8_t	msgID;
 	};
 } ubx_payload_rx_ack_nak_t;
 
 /* Tx CFG-PRT */
 typedef struct {
-	uint8_t  portID;
-	uint8_t  reserved0;
-	uint16_t txReady;
-	uint32_t mode;
-	uint32_t baudRate;
-	uint16_t inProtoMask;
-	uint16_t outProtoMask;
-	uint16_t flags;
-	uint16_t reserved5;
+	uint8_t		portID;
+	uint8_t		reserved0;
+	uint16_t	txReady;
+	uint32_t	mode;
+	uint32_t	baudRate;
+	uint16_t	inProtoMask;
+	uint16_t	outProtoMask;
+	uint16_t	flags;
+	uint16_t	reserved5;
 } ubx_payload_tx_cfg_prt_t;
 
 /* Tx CFG-RATE */
 typedef struct {
-	uint16_t measRate;      /**< Measurement Rate, GPS measurements are taken every measRate milliseconds */
-	uint16_t navRate;       /**< Navigation Rate, in number of measurement cycles. This parameter cannot be changed, and must be set to 1 */
-	uint16_t timeRef;       /**< Alignment to reference time: 0 = UTC time, 1 = GPS time */
+	uint16_t	measRate;	/**< Measurement Rate, GPS measurements are taken every measRate milliseconds */
+	uint16_t	navRate;	/**< Navigation Rate, in number of measurement cycles. This parameter cannot be changed, and must be set to 1 */
+	uint16_t	timeRef;	/**< Alignment to reference time: 0 = UTC time, 1 = GPS time */
 } ubx_payload_tx_cfg_rate_t;
 
 /* Tx CFG-CFG */
 typedef struct {
-	uint32_t clearMask;     /**< Clear settings */
-	uint32_t saveMask;      /**< Save settings */
-	uint32_t loadMask;      /**< Load settings */
-	uint8_t  deviceMask;    /**< Storage devices to apply this top */
+	uint32_t	clearMask;	/**< Clear settings */
+	uint32_t	saveMask;	/**< Save settings */
+	uint32_t	loadMask;	/**< Load settings */
+	uint8_t		deviceMask; /**< Storage devices to apply this top */
 } ubx_payload_tx_cfg_cfg_t;
 
 /* Tx CFG-VALSET (protocol version 27+) */
 typedef struct {
-	uint8_t version;        /**< Message version, set to 0 */
-	uint8_t layers;         /**< The layers where the configuration should be applied (@see UBX_CFG_LAYER_*) */
-	uint8_t reserved1[2];
-	uint8_t cfgData;        /**< configuration data (key and value pairs, max 64) */
+	uint8_t     version;	/**< Message version, set to 0 */
+	uint8_t     layers;	/**< The layers where the configuration should be applied (@see UBX_CFG_LAYER_*) */
+	uint8_t     reserved1[2];
+	uint8_t		cfgData;	/**< configuration data (key and value pairs, max 64) */
 } ubx_payload_tx_cfg_valset_t;
+
+#define UBX_CFG_LAYER_RAM (1 << 0)
+#define UBX_CFG_LAYER_BBR (1 << 1)
+#define UBX_CFG_LAYER_FLASH (1 << 2)
 
 /* Tx CFG-NAV5 */
 typedef struct {
-	uint16_t mask;
-	uint8_t  dynModel;       /**< Dynamic Platform model: 0 Portable, 2 Stationary, 3 Pedestrian, 4 Automotive, 5 Sea, 6 Airborne <1g, 7 Airborne <2g, 8 Airborne <4g */
-	uint8_t  fixMode;        /**< Position Fixing Mode: 1 2D only, 2 3D only, 3 Auto 2D/3D */
-	int32_t  fixedAlt;
-	uint32_t fixedAltVar;
-	int8_t   minElev;
-	uint8_t  drLimit;
-	uint16_t pDop;
-	uint16_t tDop;
-	uint16_t pAcc;
-	uint16_t tAcc;
-	uint8_t  staticHoldThresh;
-	uint8_t  dgpsTimeOut;
-	uint8_t  cnoThreshNumSVs;        /**< (ubx7+ only, else 0) */
-	uint8_t  cnoThresh;              /**< (ubx7+ only, else 0) */
-	uint16_t reserved;
-	uint16_t staticHoldMaxDist;      /**< (ubx8+ only, else 0) */
-	uint8_t  utcStandard;            /**< (ubx8+ only, else 0) */
-	uint8_t  reserved3;
-	uint32_t reserved4;
+	uint16_t	mask;
+	uint8_t		dynModel;	/**< Dynamic Platform model: 0 Portable, 2 Stationary, 3 Pedestrian, 4 Automotive, 5 Sea, 6 Airborne <1g, 7 Airborne <2g, 8 Airborne <4g */
+	uint8_t		fixMode;	/**< Position Fixing Mode: 1 2D only, 2 3D only, 3 Auto 2D/3D */
+	int32_t		fixedAlt;
+	uint32_t	fixedAltVar;
+	int8_t		minElev;
+	uint8_t		drLimit;
+	uint16_t	pDop;
+	uint16_t	tDop;
+	uint16_t	pAcc;
+	uint16_t	tAcc;
+	uint8_t		staticHoldThresh;
+	uint8_t		dgpsTimeOut;
+	uint8_t		cnoThreshNumSVs;	/**< (ubx7+ only, else 0) */
+	uint8_t		cnoThresh;		/**< (ubx7+ only, else 0) */
+	uint16_t	reserved;
+	uint16_t	staticHoldMaxDist;	/**< (ubx8+ only, else 0) */
+	uint8_t		utcStandard;		/**< (ubx8+ only, else 0) */
+	uint8_t		reserved3;
+	uint32_t	reserved4;
 } ubx_payload_tx_cfg_nav5_t;
 
 /* tx cfg-rst */
 typedef struct {
-	uint16_t navBbrMask;
-	uint8_t  resetMode;
-	uint8_t  reserved1;
+	uint16_t	navBbrMask;
+	uint8_t		resetMode;
+	uint8_t		reserved1;
 } ubx_payload_tx_cfg_rst_t;
 
 /* tx cfg-sbas */
 typedef struct {
-	uint8_t  mode;
-	uint8_t  usage;
-	uint8_t  maxSBAS;
-	uint8_t  scanmode2;
-	uint32_t scanmode1;
+	uint8_t		mode;
+	uint8_t		usage;
+	uint8_t		maxSBAS;
+	uint8_t		scanmode2;
+	uint32_t	scanmode1;
 } ubx_payload_tx_cfg_sbas_t;
 
 /* Tx CFG-MSG */
 typedef struct {
 	union {
-		uint16_t msg;
+		uint16_t	msg;
 		struct {
-			uint8_t msgClass;
-			uint8_t msgID;
+			uint8_t	msgClass;
+			uint8_t	msgID;
 		};
 	};
 	uint8_t rate;
@@ -759,95 +708,51 @@ typedef struct {
 
 /* CFG-TMODE3 ublox 8 (protocol version >= 20) */
 typedef struct {
-	uint8_t  version;
-	uint8_t  reserved1;
-	uint16_t flags;
-	int32_t  ecefXOrLat;
-	int32_t  ecefYOrLon;
-	int32_t  ecefZOrAlt;
-	int8_t   ecefXOrLatHP;
-	int8_t   ecefYOrLonHP;
-	int8_t   ecefZOrAltHP;
-	uint8_t  reserved2;
-	uint32_t fixedPosAcc;
-	uint32_t svinMinDur;
-	uint32_t svinAccLimit;
-	uint8_t  reserved3[8];
+	uint8_t     version;
+	uint8_t     reserved1;
+	uint16_t    flags;
+	int32_t     ecefXOrLat;
+	int32_t     ecefYOrLon;
+	int32_t     ecefZOrAlt;
+	int8_t      ecefXOrLatHP;
+	int8_t      ecefYOrLonHP;
+	int8_t      ecefZOrAltHP;
+	uint8_t     reserved2;
+	uint32_t    fixedPosAcc;
+	uint32_t    svinMinDur;
+	uint32_t    svinAccLimit;
+	uint8_t     reserved3[8];
 } ubx_payload_tx_cfg_tmode3_t;
-
-typedef struct {
-	uint8_t msgVer;           /**< Message version (expected 0x00) */
-	uint8_t numTrkChHw;       /**< Number of tracking channels available (read only) */
-	uint8_t numTrkChUse;      /**< Number of tracking channels to use (0xFF for numTrkChHw) */
-	uint8_t numConfigBlocks;  /**< Count of repeated blocks */
-
-	struct ubx_payload_tx_cgf_gnss_block_t {
-		uint8_t gnssId;     /**< GNSS ID */
-		uint8_t resTrkCh;   /**< Number of reseved (minimum) tracking channels */
-		uint8_t maxTrkCh;   /**< Maximum number or tracking channels */
-		uint8_t reserved1;
-		uint32_t flags;     /**< Bitfield flags (see UBX_TX_CFG_GNSS_FLAGS_*) */
-	};
-
-	ubx_payload_tx_cgf_gnss_block_t block[7];  /**< GPS, SBAS, Galileo, BeiDou, IMES 0-8, QZSS, GLONASS */
-} ubx_payload_tx_cfg_gnss_t;
-
-/* NAV RELPOSNED (protocol version 27+) */
-typedef struct {
-	uint8_t     version;         /**< message version (expected 0x01) */
-	uint8_t     reserved0;
-	uint16_t    refStationId;    /**< Reference station ID. Must be in the range 0..4095 */
-	uint32_t    iTOW;            /**< [ms] GPS time of week of the navigation epoch */
-	int32_t     relPosN;         /**< [cm] North component of relative position vector */
-	int32_t     relPosE;         /**< [cm] East component of relative position vector */
-	int32_t     relPosD;         /**< [cm] Down component of relative position vector */
-	int32_t     relPosLength;    /**< [cm] Length of the relative position vector */
-	int32_t     relPosHeading;   /**< [1e-5 deg] Heading of the relative position vector */
-	uint32_t    reserved1;
-	int8_t      relPosHPN;       /**< [0.1 mm] High-precision North component of relative position vector */
-	int8_t      relPosHPE;       /**< [0.1 mm] High-precision East component of relative position vector */
-	int8_t      relPosHPD;       /**< [0.1 mm] High-precision Down component of relative position vector */
-	int8_t      relPosHPLength;  /**< [0.1 mm] High-precision component of the length of the relative position vector */
-	uint32_t    accN;            /**< [0.1 mm] Accuracy of relative position North component */
-	uint32_t    accE;            /**< [0.1 mm] Accuracy of relative position East component */
-	uint32_t    accD;            /**< [0.1 mm] Accuracy of relative position Down component */
-	uint32_t    accLength;       /**< [0.1 mm] Accuracy of the length of the relative position vector */
-	uint32_t    accHeading;      /**< [1e-5 deg] Accuracy of the heading of the relative position vector */
-	uint32_t    reserved2;
-	uint32_t    flags;
-} ubx_payload_rx_nav_relposned_t;
 
 /* General message and payload buffer union */
 typedef union {
-	ubx_payload_rx_nav_pvt_t          payload_rx_nav_pvt;
-	ubx_payload_rx_nav_posllh_t       payload_rx_nav_posllh;
-	ubx_payload_rx_nav_sol_t          payload_rx_nav_sol;
-	ubx_payload_rx_nav_dop_t          payload_rx_nav_dop;
-	ubx_payload_rx_nav_timeutc_t      payload_rx_nav_timeutc;
-	ubx_payload_rx_nav_svinfo_part1_t payload_rx_nav_svinfo_part1;
-	ubx_payload_rx_nav_svinfo_part2_t payload_rx_nav_svinfo_part2;
-	ubx_payload_rx_nav_sat_part1_t    payload_rx_nav_sat_part1;
-	ubx_payload_rx_nav_sat_part2_t    payload_rx_nav_sat_part2;
-	ubx_payload_rx_nav_svin_t         payload_rx_nav_svin;
-	ubx_payload_rx_nav_velned_t       payload_rx_nav_velned;
-	ubx_payload_rx_mon_hw_ubx6_t      payload_rx_mon_hw_ubx6;
-	ubx_payload_rx_mon_hw_ubx7_t      payload_rx_mon_hw_ubx7;
-	ubx_payload_rx_mon_rf_t           payload_rx_mon_rf;
-	ubx_payload_rx_mon_ver_part1_t    payload_rx_mon_ver_part1;
-	ubx_payload_rx_mon_ver_part2_t    payload_rx_mon_ver_part2;
-	ubx_payload_rx_ack_ack_t          payload_rx_ack_ack;
-	ubx_payload_rx_ack_nak_t          payload_rx_ack_nak;
-	ubx_payload_tx_cfg_prt_t          payload_tx_cfg_prt;
-	ubx_payload_tx_cfg_rate_t         payload_tx_cfg_rate;
-	ubx_payload_tx_cfg_nav5_t         payload_tx_cfg_nav5;
-	ubx_payload_tx_cfg_rst_t          payload_tx_cfg_rst;
-	ubx_payload_tx_cfg_sbas_t         payload_tx_cfg_sbas;
-	ubx_payload_tx_cfg_msg_t          payload_tx_cfg_msg;
-	ubx_payload_tx_cfg_tmode3_t       payload_tx_cfg_tmode3;
-	ubx_payload_tx_cfg_cfg_t          payload_tx_cfg_cfg;
-	ubx_payload_tx_cfg_valset_t       payload_tx_cfg_valset;
-	ubx_payload_tx_cfg_gnss_t         payload_tx_cfg_gnss;
-	ubx_payload_rx_nav_relposned_t    payload_rx_nav_relposned;
+	ubx_payload_rx_nav_pvt_t		payload_rx_nav_pvt;
+	ubx_payload_rx_nav_posllh_t		payload_rx_nav_posllh;
+	ubx_payload_rx_nav_sol_t		payload_rx_nav_sol;
+	ubx_payload_rx_nav_dop_t		payload_rx_nav_dop;
+	ubx_payload_rx_nav_timeutc_t		payload_rx_nav_timeutc;
+	ubx_payload_rx_nav_svinfo_part1_t	payload_rx_nav_svinfo_part1;
+	ubx_payload_rx_nav_svinfo_part2_t	payload_rx_nav_svinfo_part2;
+	ubx_payload_rx_nav_sat_part1_t		payload_rx_nav_sat_part1;
+	ubx_payload_rx_nav_sat_part2_t		payload_rx_nav_sat_part2;
+	ubx_payload_rx_nav_svin_t		payload_rx_nav_svin;
+	ubx_payload_rx_nav_velned_t		payload_rx_nav_velned;
+	ubx_payload_rx_mon_hw_ubx6_t		payload_rx_mon_hw_ubx6;
+	ubx_payload_rx_mon_hw_ubx7_t		payload_rx_mon_hw_ubx7;
+	ubx_payload_rx_mon_rf_t			payload_rx_mon_rf;
+	ubx_payload_rx_mon_ver_part1_t		payload_rx_mon_ver_part1;
+	ubx_payload_rx_mon_ver_part2_t		payload_rx_mon_ver_part2;
+	ubx_payload_rx_ack_ack_t		payload_rx_ack_ack;
+	ubx_payload_rx_ack_nak_t		payload_rx_ack_nak;
+	ubx_payload_tx_cfg_prt_t		payload_tx_cfg_prt;
+	ubx_payload_tx_cfg_rate_t		payload_tx_cfg_rate;
+	ubx_payload_tx_cfg_nav5_t		payload_tx_cfg_nav5;
+	ubx_payload_tx_cfg_rst_t		payload_tx_cfg_rst;
+	ubx_payload_tx_cfg_sbas_t		payload_tx_cfg_sbas;
+	ubx_payload_tx_cfg_msg_t		payload_tx_cfg_msg;
+	ubx_payload_tx_cfg_tmode3_t		payload_tx_cfg_tmode3;
+	ubx_payload_tx_cfg_cfg_t		payload_tx_cfg_cfg;
+	ubx_payload_tx_cfg_valset_t		payload_tx_cfg_valset;
 } ubx_buf_t;
 
 #pragma pack(pop)
@@ -884,122 +789,22 @@ typedef enum {
 	UBX_ACK_GOT_NAK
 } ubx_ack_state_t;
 
+
 class GPSDriverUBX : public GPSBaseStationSupport
 {
 public:
-	enum class UBXMode : uint8_t {
-		Normal,              ///< all non-heading configurations
-		RoverWithMovingBase, ///< expect RTCM input on UART2 from a moving base for heading output
-		MovingBase,          ///< RTCM output on UART2 to a rover (GPS is installed on the vehicle)
-	};
-
 	GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void *callback_user,
-		     sensor_gps_s *gps_position, satellite_info_s *satellite_info,
-		     uint8_t dynamic_model = 7,
-		     float heading_offset = 0.f,
-		     UBXMode mode = UBXMode::Normal);
+		     struct vehicle_gps_position_s *gps_position,
+		     struct satellite_info_s *satellite_info,
+		     uint8_t dynamic_model = 7);
 
 	virtual ~GPSDriverUBX();
 
-	int configure(unsigned &baudrate, const GPSConfig &config) override;
 	int receive(unsigned timeout) override;
+	int configure(unsigned &baudrate, OutputMode output_mode) override;
 	int reset(GPSRestartType restart_type) override;
 
-	bool shouldInjectRTCM() override { return _mode != UBXMode::RoverWithMovingBase; }
-
-	enum class Board : uint8_t {
-		unknown = 0,
-		u_blox5 = 5,
-		u_blox6 = 6,
-		u_blox7 = 7,
-		u_blox8 = 8, ///< M8N or M8P
-		u_blox9 = 9, ///< M9N, or any F9*, except F9P
-		u_blox9_F9P = 10, ///< F9P
-	};
-
-	const Board &board() const { return _board; }
-
 private:
-
-private:
-
-	int activateRTCMOutput(bool reduce_update_rate);
-
-	/**
-	 * While parsing add every byte (except the sync bytes) to the checksum
-	 */
-	void addByteToChecksum(const uint8_t);
-
-	/**
-	 * Calculate & add checksum for given buffer
-	 */
-	void calcChecksum(const uint8_t *buffer, const uint16_t length, ubx_checksum_t *checksum);
-
-	/**
-	 * Configure message rate.
-	 * Note: this is deprecated with protocol version >= 27
-	 * @return true on success, false on write error
-	 */
-	bool configureMessageRate(const uint16_t msg, const uint8_t rate);
-
-	/**
-	 * Combines the configure_message_rate & wait_for_ack calls.
-	 * Note: this is deprecated with protocol version >= 27
-	 * @return true on success
-	 */
-	inline bool configureMessageRateAndAck(uint16_t msg, uint8_t rate, bool report_ack_error = false);
-
-	/**
-	 * Send configuration values and desired message rates
-	 * @param gnssSystems Set of GNSS systems to use
-	 * @return 0 on success, <0 on error
-	 */
-	int configureDevice(const GNSSSystemsMask &gnssSystems);
-	/**
-	 * Send configuration values and desired message rates (for protocol version < 27)
-	 * @param gnssSystems Set of GNSS systems to use
-	 * @return 0 on success, <0 on error
-	 */
-	int configureDevicePreV27(const GNSSSystemsMask &gnssSystems);
-
-	/**
-	 * Add a configuration value to _buf and increase the message size msg_size as needed
-	 * @param key_id one of the UBX_CFG_KEY_* constants
-	 * @param value configuration value
-	 * @param msg_size CFG-VALSET message size: this is an input & output param
-	 * @return true on success, false if buffer too small
-	 */
-	template<typename T>
-	bool cfgValset(uint32_t key_id, T value, int &msg_size);
-
-	/**
-	 * Add a configuration value that is port-specific (MSGOUT messages).
-	 * Note: Key ID must be the one for I2C, and the implementation assumes the
-	 *       Key ID's are in increasing order for the other ports: I2C, UART1, UART2, USB, SPI
-	 *       (this is a safe assumption for all MSGOUT messages according to u-blox).
-	 *
-	 * @param key_id I2C key ID
-	 * @param value configuration value
-	 * @param msg_size CFG-VALSET message size: this is an input & output param
-	 * @return true on success, false if buffer too small
-	 */
-	bool cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size);
-
-	/**
-	 * Reset the parse state machine for a fresh start
-	 */
-	void decodeInit(void);
-
-	/**
-	 * Calculate FNV1 hash
-	 */
-	uint32_t fnv1_32_str(uint8_t *str, uint32_t hval);
-
-	/**
-	 * Init _buf as CFG-VALSET
-	 * @return size of the message (without any config values)
-	 */
-	int initCfgValset();
 
 	/**
 	 * Start or restart the survey-in procees. This is only used in RTCM ouput mode.
@@ -1027,14 +832,24 @@ private:
 	 * Add payload rx byte
 	 */
 	int payloadRxAdd(const uint8_t b);
-	int payloadRxAddMonVer(const uint8_t b);
-	int payloadRxAddNavSat(const uint8_t b);
 	int payloadRxAddNavSvinfo(const uint8_t b);
+	int payloadRxAddNavSat(const uint8_t b);
+	int payloadRxAddMonVer(const uint8_t b);
 
 	/**
 	 * Finish payload rx
 	 */
 	int payloadRxDone(void);
+
+	/**
+	 * Reset the parse state machine for a fresh start
+	 */
+	void decodeInit(void);
+
+	/**
+	 * While parsing add every byte (except the sync bytes) to the checksum
+	 */
+	void addByteToChecksum(const uint8_t);
 
 	/**
 	 * Send a message
@@ -1043,47 +858,123 @@ private:
 	bool sendMessage(const uint16_t msg, const uint8_t *payload, const uint16_t length);
 
 	/**
+	 * Configure message rate.
+	 * Note: this is deprecated with protocol version >= 27
+	 * @return true on success, false on write error
+	 */
+	bool configureMessageRate(const uint16_t msg, const uint8_t rate);
+
+	/**
+	 * Calculate & add checksum for given buffer
+	 */
+	void calcChecksum(const uint8_t *buffer, const uint16_t length, ubx_checksum_t *checksum);
+
+	/**
 	 * Wait for message acknowledge
 	 */
 	int waitForAck(const uint16_t msg, const unsigned timeout, const bool report);
 
-	const Interface _interface{};
+	/**
+	 * Combines the configure_message_rate & wait_for_ack calls.
+	 * Note: this is deprecated with protocol version >= 27
+	 * @return true on success
+	 */
+	inline bool configureMessageRateAndAck(uint16_t msg, uint8_t rate, bool report_ack_error = false);
 
-	gps_abstime             _disable_cmd_last{0};
-	sensor_gps_s           *_gps_position {nullptr};
-	satellite_info_s       *_satellite_info {nullptr};
-	ubx_ack_state_t         _ack_state{UBX_ACK_IDLE};
-	ubx_buf_t               _buf{};
-	ubx_decode_state_t      _decode_state{};
-	ubx_rxmsg_state_t       _rx_state{UBX_RXMSG_IGNORE};
+	/**
+	 * Send configuration values and desired message rates
+	 * @return 0 on success, <0 on error
+	 */
+	int configureDevice();
+	/**
+	 * Send configuration values and desired message rates (for protocol version < 27)
+	 * @return 0 on success, <0 on error
+	 */
+	int configureDevicePreV27();
 
-	bool _configured{false};
-	bool _got_posllh{false};
-	bool _got_velned{false};
-	bool _proto_ver_27_or_higher{false}; ///< true if protocol version 27 or higher detected
-	bool _use_nav_pvt{false};
+	/**
+	 * Init _buf as CFG-VALSET
+	 * @return size of the message (without any config values)
+	 */
+	int initCfgValset();
 
-	uint8_t _rx_ck_a{0};
-	uint8_t _rx_ck_b{0};
-	uint8_t _dyn_model{7};  ///< ublox Dynamic platform model default 7: airborne with <2g acceleration
+	/**
+	 * New layer for ack waiting
+	 * @param msg message id for ack waiting
+	 * @return true on success, false on error
+	 */
+	bool ackWaiting(const uint16_t msg);
 
-	uint16_t _ack_waiting_msg{0};
-	uint16_t _rx_msg{};
-	uint16_t _rx_payload_index{0};
-	uint16_t _rx_payload_length{0};
+	/**
+	 * Add a configuration value to _buf and increase the message size msg_size as needed
+	 * @param key_id one of the UBX_CFG_KEY_* constants
+	 * @param value configuration value
+	 * @param msg_size CFG-VALSET message size: this is an input & output param
+	 * @return true on success, false if buffer too small
+	 */
+	template<typename T>
+	bool cfgValset(uint32_t key_id, T value, int &msg_size);
 
-	uint32_t _ubx_version{0};
+	/**
+	 * Add a configuration value that is port-specific (MSGOUT messages).
+	 * Note: Key ID must be the one for I2C, and the implementation assumes the
+	 *       Key ID's are in increasing order for the other ports: I2C, UART1, UART2, USB, SPI
+	 *       (this is a safe assumption for all MSGOUT messages according to u-blox).
+	 *
+	 * @param key_id I2C key ID
+	 * @param value configuration value
+	 * @param msg_size CFG-VALSET message size: this is an input & output param
+	 * @return true on success, false if buffer too small
+	 */
+	bool cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size);
 
-	uint64_t _last_timestamp_time{0};
+	int activateRTCMOutput();
 
-	Board _board{Board::unknown};
+	/**
+	 * Calculate FNV1 hash
+	 */
+	uint32_t fnv1_32_str(uint8_t *str, uint32_t hval);
 
-	OutputMode _output_mode{OutputMode::GPS};
+	enum class Board : uint8_t {
+		unknown = 0,
+		u_blox5 = 5,
+		u_blox6 = 6,
+		u_blox7 = 7,
+		u_blox8 = 8, ///< M8N or M8P
+		u_blox9 = 9, ///< M9N, or any F9*, except F9P
+		u_blox9_F9P = 10, ///< F9P,
+		u_blox10 = 11,	///< MAX-M10S
+	};
 
-	RTCMParsing *_rtcm_parsing{nullptr};
+	struct vehicle_gps_position_s *_gps_position {nullptr};
+	struct satellite_info_s *_satellite_info {nullptr};
+	uint64_t		_last_timestamp_time{0};
+	bool			_configured{false};
+	ubx_ack_state_t		_ack_state{UBX_ACK_IDLE};
+	bool			_got_posllh{false};
+	bool			_got_velned{false};
+	ubx_decode_state_t	_decode_state{};
+	uint16_t		_rx_msg{};
+	ubx_rxmsg_state_t	_rx_state{UBX_RXMSG_IGNORE};
+	uint16_t		_rx_payload_length{};
+	uint16_t		_rx_payload_index{};
+	uint8_t			_rx_ck_a{};
+	uint8_t			_rx_ck_b{};
+	gps_abstime		_disable_cmd_last{0};
+	uint16_t		_ack_waiting_msg{0};
+	ubx_buf_t		_buf{};
+	uint32_t		_ubx_version{0};
+	bool			_use_nav_pvt{false};
+	bool			_proto_ver_27_or_higher{false}; ///< true if protocol version 27 or higher detected
+	OutputMode		_output_mode{OutputMode::GPS};
 
-	const UBXMode _mode;
-	const float _heading_offset;
+	RTCMParsing	*_rtcm_parsing{nullptr};
+
+	const Interface		_interface;
+	Board			_board{Board::unknown};
+
+	// ublox Dynamic platform model default 7: airborne with <2g acceleration
+	uint8_t _dyn_model{7};
 };
 
 


### PR DESCRIPTION
New ubx.cpp & ubx.h files worked only with a MAX-M10S module.
This code must be injected (after some optimization, see below) to generic ubx driver.

How use this driver:
GPS baudrate in QGC must be set to AUTO value.

MAX-M10S configuration:
1. UBX_CFG_KEY_CFG_UART1_STOPBITS = 1
2. UBX_CFG_KEY_CFG_UART1_DATABITS = 0
3. UBX_CFG_KEY_CFG_UART1_PARITY = 0
4. UBX_CFG_KEY_CFG_UART1INPROT_UBX = 1
5. UBX_CFG_KEY_CFG_UART1INPROT_NMEA = 0
6. UBX_CFG_KEY_CFG_UART1OUTPROT_UBX = 1
7. UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA = 0
8. UBX_CFG_KEY_CFG_UART1_BAUDRATE = 115200
9. UBX_CFG_KEY_NAVSPG_FIXMODE = 3
10. UBX_CFG_KEY_NAVSPG_UTCSTANDARD = 3
11. UBX_CFG_KEY_NAVSPG_DYNMODEL = 7
12. UBX_CFG_KEY_ODO_USE_ODO = 0
13. UBX_CFG_KEY_ODO_USE_COG = 0
14. UBX_CFG_KEY_ODO_OUTLPVEL = 0
15. UBX_CFG_KEY_ODO_OUTLPCOG = 0
16. UBX_CFG_KEY_RATE_MEAS = 100 (10Hz)
17. UBX_CFG_KEY_RATE_NAV = 1
18. UBX_CFG_KEY_RATE_TIMEREF = 0
19. UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_UART1 = 1
20. UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_UART1 = 1
21. UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_UART1 = (_satellite_info != nullptr) ? 10 : 0
22. UBX_CFG_KEY_MSGOUT_UBX_MON_RF_UART1 = 1
23. UBX_CFG_KEY_HW_RF_LNA_MODE = 1 (low gain)
24. UBX_CFG_KEY_ITFM_ANTSETTING = 1 (pasiive ant)
25. UBX_CFG_SIGNAL_GPS_ENA = 1
26. UBX_CFG_SIGNAL_GPS_L1CA_ENA = 0
27. UBX_CFG_SIGNAL_SBAS_ENA = 0
28. UBX_CFG_SIGNAL_SBAS_L1CA_ENA = 0
29. UBX_CFG_SIGNAL_GAL_ENA = 1
30. UBX_CFG_SIGNAL_GAL_El_ENA = 0
31. UBX_CFG_SIGNAL_BDS_ENA = 1
32. UBX_CFG_SIGNAL_BDS_B1_ENA = 0
33. UBX_CFG_SIGNAL_QZSS_ENA = 0
34. UBX_CFG_SIGNAL_QZSS_L1CA_ENA = 0
35. UBX_CFG_SIGNAL_GLO_ENA = 1
36. UBX_CFG_SIGNAL_GLO_L1_ENA = 0

TODO: Fix send GPS configuration buffer with multiply key-value cfg pairs.

Standart configuration code with multiply key-value cfg pairs don't worked:
-----
cfg_valset_msg_size = initCfgValset();
cfgValset<uint8_t>(UBX_CFG_KEY_XXX_XXX, XXX, cfg_valset_msg_size); //First key-value cfg pair
cfgValset<uint8_t>(UBX_CFG_KEY_XXX_XXX, XXX, cfg_valset_msg_size); //2 key-value cfg pair
cfgValset<uint8_t>(UBX_CFG_KEY_XXX_XXX, XXX, cfg_valset_msg_size); //3 key-value cfg pair
cfgValset<uint8_t>(UBX_CFG_KEY_XXX_XXX, XXX, cfg_valset_msg_size); //4 key-value cfg pair
send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
ACK ERROR
-----
After send this payload packet GPS don't send ACK msg. But after send one key-value pair GPS send ACK msg. This behaviour must be fixed.
-----
cfg_valset_msg_size = initCfgValset();
cfgValset<uint8_t>(UBX_CFG_KEY_XXX_XXX, XXX, cfg_valset_msg_size); //1 key-value cfg pair
send_msg_flag = sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
cfg_valset_success = ackWaiting(UBX_MSG_CFG_VALSET);
ACK OK
-----