### PR TITLE
Femto gps driver : Change "UNLOGALL" command

### DIFF
--- a/src/femtomes.cpp
+++ b/src/femtomes.cpp
@@ -564,7 +564,7 @@ int GPSDriverFemto::configure(unsigned &baudrate, const GPSConfig &config)
 		FEMTO_DEBUG("Femto: baudrate set to %i", test_baudrate);
 
 		for (int run = 0; run < 2; ++run) { /** try several times*/
-			if (writeAckedCommandFemto("UNLOGALL\r\n", "<UNLOGALL OK", FEMTO_RESPONSE_TIMEOUT) == 0 &&
+			if (writeAckedCommandFemto("UNLOGALL THISPORT\r\n", "<UNLOGALL OK", FEMTO_RESPONSE_TIMEOUT) == 0 &&
 			    writeAckedCommandFemto("VERSION\r\n", "<VERSION OK", FEMTO_RESPONSE_TIMEOUT) == 0) {
 				FEMTO_DEBUG("Femto: got port for baudrate %i", test_baudrate);
 				success = true;
@@ -599,7 +599,7 @@ int GPSDriverFemto::configure(unsigned &baudrate, const GPSConfig &config)
 
 		for (int run = 0; run < 10; ++run) {
 			/** We ask for the port config again. If we get a reply, we know that the changed settings work.*/
-			if (writeAckedCommandFemto("UNLOGALL\r\n", "<UNLOGALL OK", FEMTO_RESPONSE_TIMEOUT) == 0 &&
+			if (writeAckedCommandFemto("UNLOGALL THISPORT\r\n", "<UNLOGALL OK", FEMTO_RESPONSE_TIMEOUT) == 0 &&
 			    writeAckedCommandFemto("VERSION\r\n", "<VERSION OK", FEMTO_RESPONSE_TIMEOUT) == 0) {
 				success = true;
 				break;


### PR DESCRIPTION
1. Change UNLOGALL command to UNLOGALL THISPORT for only clear current connected port of the device.