### PR TITLE
Disable gps heading for UBX driver in RTK float fix type

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2039,13 +2039,7 @@ GPSDriverUBX::payloadRxDone()
 			bool carrier_solution_fixed = _buf.payload_rx_nav_relposned.flags & (1 << 4);
 			(void)rel_length_acc;
 
-			// RTK float fix type is not accurate enough 
-			if (!carrier_solution_fixed)
-			{
-				heading_valid = false; 
-			}
-
-			if (heading_valid && rel_pos_valid && rel_length < 1000.f) { // validity & sanity checks
+			if (heading_valid && rel_pos_valid && rel_length < 1000.f && carrier_solution_fixed) { // validity & sanity checks
 				heading *= M_PI_F / 180.0f; // deg to rad, now in range [0, 2pi]
 				heading -= _heading_offset; // range: [-pi, 3pi]
 
@@ -2103,11 +2097,6 @@ GPSDriverUBX::payloadRxDone()
 			gps_rel.reference_observations_miss  = _buf.payload_rx_nav_relposned.flags & (1 << 7);
 			gps_rel.heading_valid                = _buf.payload_rx_nav_relposned.flags & (1 << 8);
 			gps_rel.relative_position_normalized = _buf.payload_rx_nav_relposned.flags & (1 << 9);
-
-			if (!gps_rel.carrier_solution_fixed)
-			{
-				gps_rel.heading_valid = false; 
-			}
 
 			gotRelativePositionMessage(gps_rel);
 		}

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2043,8 +2043,6 @@ GPSDriverUBX::payloadRxDone()
 			if (_gps_position->fix_type != 6)
 			{
 				heading_valid = false; 
-				_gps_position->heading = NAN;
-				_gps_position->heading_acc = NAN; 
 			}
 
 			if (heading_valid && rel_pos_valid && rel_length < 1000.f) { // validity & sanity checks
@@ -2085,17 +2083,8 @@ GPSDriverUBX::payloadRxDone()
 			gps_rel.position_length = (_buf.payload_rx_nav_relposned.relPosLength
 						   + _buf.payload_rx_nav_relposned.relPosHPLength * 1e-2f) * 1e-2f;
 
-			// RTK float fix type is not accurate enough 
-			if (_gps_position->fix_type != 6)
-			{
-				gps_rel.heading = NAN;
-				gps_rel.heading_acc = NAN; 
-			}
-			else
-			{
-				gps_rel.heading = _buf.payload_rx_nav_relposned.relPosHeading * 1e-5f * (M_PI_F / 180.f);  // 1e-5 deg -> radians
-				gps_rel.heading_accuracy = _buf.payload_rx_nav_relposned.accHeading * 1e-5f * (M_PI_F / 180.f); // 1e-5 deg -> radians
-			}
+			gps_rel.heading = _buf.payload_rx_nav_relposned.relPosHeading * 1e-5f * (M_PI_F / 180.f);  // 1e-5 deg -> radians
+			gps_rel.heading_accuracy = _buf.payload_rx_nav_relposned.accHeading * 1e-5f * (M_PI_F / 180.f); // 1e-5 deg -> radians		
 
 			// Accuracy of relative position in 0.1 mm
 			gps_rel.position_accuracy[0] = _buf.payload_rx_nav_relposned.accN * 1e-4f; // 0.1mm -> m

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -51,7 +51,6 @@
  */
 
 #include <string.h>
-#include <math.h>
 
 #include "rtcm.h"
 #include "ubx.h"
@@ -2084,7 +2083,7 @@ GPSDriverUBX::payloadRxDone()
 						   + _buf.payload_rx_nav_relposned.relPosHPLength * 1e-2f) * 1e-2f;
 
 			gps_rel.heading = _buf.payload_rx_nav_relposned.relPosHeading * 1e-5f * (M_PI_F / 180.f);  // 1e-5 deg -> radians
-			gps_rel.heading_accuracy = _buf.payload_rx_nav_relposned.accHeading * 1e-5f * (M_PI_F / 180.f); // 1e-5 deg -> radians		
+			gps_rel.heading_accuracy = _buf.payload_rx_nav_relposned.accHeading * 1e-5f * (M_PI_F / 180.f); // 1e-5 deg -> radians
 
 			// Accuracy of relative position in 0.1 mm
 			gps_rel.position_accuracy[0] = _buf.payload_rx_nav_relposned.accN * 1e-4f; // 0.1mm -> m

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2036,10 +2036,11 @@ GPSDriverUBX::payloadRxDone()
 			float rel_length_acc = _buf.payload_rx_nav_relposned.accLength * 1e-2f;
 			bool heading_valid = _buf.payload_rx_nav_relposned.flags & (1 << 8);
 			bool rel_pos_valid = _buf.payload_rx_nav_relposned.flags & (1 << 2);
+			bool carrier_solution_fixed = _buf.payload_rx_nav_relposned.flags & (1 << 4);
 			(void)rel_length_acc;
 
 			// RTK float fix type is not accurate enough 
-			if (_gps_position->fix_type != 6)
+			if (!carrier_solution_fixed)
 			{
 				heading_valid = false; 
 			}
@@ -2103,7 +2104,7 @@ GPSDriverUBX::payloadRxDone()
 			gps_rel.heading_valid                = _buf.payload_rx_nav_relposned.flags & (1 << 8);
 			gps_rel.relative_position_normalized = _buf.payload_rx_nav_relposned.flags & (1 << 9);
 
-			if (_gps_position->fix_type != 6)
+			if (!gps_rel.carrier_solution_fixed)
 			{
 				gps_rel.heading_valid = false; 
 			}


### PR DESCRIPTION
I've been testing the dual GPS heading using the ublox F9P chip. I get big angles spikes (yellow vertical lines in the attached file) as the gps fix_type changes from float RTK to fixed RTK. Furthermore, I see no changes in the heading accuracy. 

![RTKFloatFixType](https://user-images.githubusercontent.com/74473718/163023205-f190c3e3-5bd7-4a0b-ade9-1e9fab10bac3.png)

Finally, as expected, I've observed that the heading estimates are always more precise in RTK fixed: 

![FixTypeResults](https://user-images.githubusercontent.com/74473718/163023178-d6a14739-2ed6-4dbb-a4ec-93f2ff04d3f8.png)


A simple solution, for now, is to disable the GPS heading when we are in RTK float fix type. 

Note: I believe that @dagar and @bresch have also experienced drops in accuracy when switching from RTK float to RTK fixed fix type. 

