### PR TITLE
sbf: fix overrun on invalid length

### DIFF
--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -462,7 +462,9 @@ int GPSDriverSBF::payloadRxDone()
 	struct tm timeinfo;
 	time_t epoch;
 
-	if (_buf.length <= 4 || _buf.crc16 != crc16(reinterpret_cast<uint8_t *>(&_buf) + 4, _buf.length - 4)) {
+	if (_buf.length <= 4 ||
+		_buf.length > _rx_payload_index ||
+		_buf.crc16 != crc16(reinterpret_cast<uint8_t *>(&_buf) + 4, _buf.length - 4)) {
 		return 0;
 	}
 


### PR DESCRIPTION
Before checking the CRC across header and payload, we need to check if the length is valid. If the length is longer than what we have read into the buffer, it must be invalid and we don't have to bother with the CRC.

This should fix a potential segfault where the CRC overruns the allocated buffer due to a corrupt length field.

Fixes #103 as discovered by @devbharat.