### PR TITLE
Enable RTCM input on moving base

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -752,7 +752,7 @@ int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
 		// enable RTCM output on uart1
 		cfg_valset_msg_size = initCfgValset();
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1, cfg_valset_msg_size);


### PR DESCRIPTION
This PR allows for a moving base to receive RTCM corrections while outputting them as well.

QGC with Fixed Base -> Radio -> FC -> dronecan RTCMStream -> Moving Base -> dronecan  MovingBaselineData -> Rover with Heading

https://review.px4.io/plot_app?log=08626ac1-09c9-4ac5-a272-77a1fc0e61ca