### PR TITLE
ZED-F9P UART2 Baudrate Configurability and New UBX Mode.

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -513,7 +513,7 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 	return 0;
 }
 
-int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems, int32_t uart2_baudrate)
+int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems, const int32_t uart2_baudrate)
 {
 	/* set configuration parameters */
 	int cfg_valset_msg_size = initCfgValset();

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -69,14 +69,15 @@
 
 GPSDriverUBX::GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void *callback_user,
 			   sensor_gps_s *gps_position, satellite_info_s *satellite_info, uint8_t dynamic_model,
-			   float heading_offset, UBXMode mode) :
+			   float heading_offset, int32_t uart2_baudrate, UBXMode mode) :
 	GPSBaseStationSupport(callback, callback_user),
 	_interface(gpsInterface),
 	_gps_position(gps_position),
 	_satellite_info(satellite_info),
 	_dyn_model(dynamic_model),
 	_mode(mode),
-	_heading_offset(heading_offset)
+	_heading_offset(heading_offset),
+	_uart2_baudrate(uart2_baudrate)
 {
 	decodeInit();
 }
@@ -331,7 +332,7 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 	int ret;
 
 	if (_proto_ver_27_or_higher) {
-		ret = configureDevice(config.gnss_systems);
+		ret = configureDevice(config.gnss_systems, _uart2_baudrate);
 
 	} else {
 		ret = configureDevicePreV27(config.gnss_systems);
@@ -512,7 +513,7 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 	return 0;
 }
 
-int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
+int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems, int32_t uart2_baudrate)
 {
 	/* set configuration parameters */
 	int cfg_valset_msg_size = initCfgValset();
@@ -670,9 +671,7 @@ int GPSDriverUBX::configureDevice(const GNSSSystemsMask &gnssSystems)
 		}
 	}
 
-	int uart2_baudrate = 230400;
-
-	if (_mode == UBXMode::RoverWithMovingBase) {
+	if (_mode == UBXMode::RoverWithStaticBaseUart2 || _mode == UBXMode::RoverWithMovingBase) {
 		UBX_DEBUG("Configuring UART2 for rover");
 		cfg_valset_msg_size = initCfgValset();
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -980,7 +980,7 @@ private:
 	 * @param uart2_baudrate Baudrate of F9P's UART2 port
 	 * @return 0 on success, <0 on error
 	 */
-	int configureDevice(const GNSSSystemsMask &gnssSystems, int32_t uart2_baudrate);
+	int configureDevice(const GNSSSystemsMask &gnssSystems, const int32_t uart2_baudrate);
 	/**
 	 * Send configuration values and desired message rates (for protocol version < 27)
 	 * @param gnssSystems Set of GNSS systems to use
@@ -1110,7 +1110,7 @@ private:
 
 	const UBXMode _mode;
 	const float _heading_offset;
-	int32_t _uart2_baudrate;
+	const int32_t _uart2_baudrate;
 };
 
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -910,6 +910,7 @@ class GPSDriverUBX : public GPSBaseStationSupport
 public:
 	enum class UBXMode : uint8_t {
 		Normal,                    ///< all non-heading configurations
+		RoverWithStaticBaseUart2,  ///< expect RTCM input on UART2 from a static base.
 		RoverWithMovingBase,       ///< expect RTCM input on UART2 from a moving base for heading output
 		MovingBase,                ///< RTCM output on UART2 to a rover (GPS is installed on the vehicle)
 		RoverWithMovingBaseUART1, ///< expect RTCM input on UART1 from a moving base for heading output
@@ -920,6 +921,7 @@ public:
 		     sensor_gps_s *gps_position, satellite_info_s *satellite_info,
 		     uint8_t dynamic_model = 7,
 		     float heading_offset = 0.f,
+		     int32_t uart2_baudrate = 57600,
 		     UBXMode mode = UBXMode::Normal);
 
 	virtual ~GPSDriverUBX();
@@ -975,9 +977,10 @@ private:
 	/**
 	 * Send configuration values and desired message rates
 	 * @param gnssSystems Set of GNSS systems to use
+	 * @param uart2_baudrate Baudrate of F9P's UART2 port
 	 * @return 0 on success, <0 on error
 	 */
-	int configureDevice(const GNSSSystemsMask &gnssSystems);
+	int configureDevice(const GNSSSystemsMask &gnssSystems, int32_t uart2_baudrate);
 	/**
 	 * Send configuration values and desired message rates (for protocol version < 27)
 	 * @param gnssSystems Set of GNSS systems to use
@@ -1107,6 +1110,7 @@ private:
 
 	const UBXMode _mode;
 	const float _heading_offset;
+	int32_t _uart2_baudrate;
 };
 
 


### PR DESCRIPTION
## Describe the problem solved by this pull request
When using the U-blox ZED-F9P GPS module, users may want to use the GPS module's UART2 port to send or receive RTCM corrections using a Telemetry Radio, rather than hard wiring this port to another module. These radios operate at 57600 baud out of the box. But the UART2 baudrate is hard coded to 230400 baud. This PR allows us to configure the Baud Rate of the ZED-F9P's UART2 port through a QGC param.

Additionally, the existing modes that the **GPS_UBX_MODE** param covers misses one potential mode -- when a user is sending RTCM corrections from a _static_ base, or other _static_ correction source, directly to UART2. The existing modes that enable UART2 assume a moving base configuration. I've called this new mode **Rover With Static Base on UART2**. This mode is functionally equivalent to Rover with moving base on UART2 (Heading mode).

This PR to the GPS Driver must be merged alongside the corresponding PX4-Autopilot PR here: https://github.com/PX4/PX4-Autopilot/pull/20133