### PR TITLE
ubx: add support for enabling/disabling protocols at the I2C interface

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -184,9 +184,19 @@ public:
 		ENABLE_GLONASS =    1 << 4
 	};
 
+	enum class InterfaceProtocolsMask : int32_t {
+		ALL_DISABLED =       0,
+		I2C_IN_PROT_UBX =    1 << 0,
+		I2C_IN_PROT_NMEA =   1 << 1,
+		I2C_IN_PROT_RTCM3X = 1 << 2,
+		I2C_OUT_PROT_UBX =   1 << 3,
+		I2C_OUT_PROT_NMEA =  1 << 4
+	};
+
 	struct GPSConfig {
 		OutputMode output_mode;
 		GNSSSystemsMask gnss_systems;
+		InterfaceProtocolsMask interface_protocols;
 	};
 
 
@@ -315,6 +325,11 @@ protected:
 };
 
 inline bool operator&(GPSHelper::GNSSSystemsMask a, GPSHelper::GNSSSystemsMask b)
+{
+	return static_cast<int32_t>(a) & static_cast<int32_t>(b);
+}
+
+inline bool operator&(GPSHelper::InterfaceProtocolsMask a, GPSHelper::InterfaceProtocolsMask b)
 {
 	return static_cast<int32_t>(a) & static_cast<int32_t>(b);
 }

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -976,11 +976,11 @@ private:
 
 	/**
 	 * Send configuration values and desired message rates
-	 * @param gnssSystems Set of GNSS systems to use
+	 * @param config The configuration includes GNSS systems to use and protocol for interfaces
 	 * @param uart2_baudrate Baudrate of F9P's UART2 port
 	 * @return 0 on success, <0 on error
 	 */
-	int configureDevice(const GNSSSystemsMask &gnssSystems, const int32_t uart2_baudrate);
+	int configureDevice(const GPSConfig &config, const int32_t uart2_baudrate);
 	/**
 	 * Send configuration values and desired message rates (for protocol version < 27)
 	 * @param gnssSystems Set of GNSS systems to use


### PR DESCRIPTION
Support for U-Blox driver to be able to change protocols at the I2C interface.
Another part will be done at PX4 with param. 

