### PR TITLE
ubx: add missing  out RTC3X protocol flag for I2C interface

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -185,12 +185,13 @@ public:
 	};
 
 	enum class InterfaceProtocolsMask : int32_t {
-		ALL_DISABLED =       0,
-		I2C_IN_PROT_UBX =    1 << 0,
-		I2C_IN_PROT_NMEA =   1 << 1,
-		I2C_IN_PROT_RTCM3X = 1 << 2,
-		I2C_OUT_PROT_UBX =   1 << 3,
-		I2C_OUT_PROT_NMEA =  1 << 4
+		ALL_DISABLED =        0,
+		I2C_IN_PROT_UBX =     1 << 0,
+		I2C_IN_PROT_NMEA =    1 << 1,
+		I2C_IN_PROT_RTCM3X =  1 << 2,
+		I2C_OUT_PROT_UBX =    1 << 3,
+		I2C_OUT_PROT_NMEA =   1 << 4,
+		I2C_OUT_PROT_RTCM3X = 1 << 5
 	};
 
 	struct GPSConfig {

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -666,7 +666,8 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 				   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_NMEA, cfg_valset_msg_size);
 
 		if (_board == Board::u_blox9_F9P) {
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X,
+					   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_RTCM3X, cfg_valset_msg_size);
 		}
 
 		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {


### PR DESCRIPTION
Addition for https://github.com/PX4/PX4-GPSDrivers/pull/119 since I missed RTC3X for I2C OUT after it moved for F9P only. 