### PR TITLE
Adding MSG_NAV_HPPOSLLH for high precision RTK positioning 

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1964,8 +1964,8 @@ GPSDriverUBX::payloadRxDone()
 
 		_got_posllh = true;
 		_got_velned = true;
-		ret = 1;
 
+		ret = 1;
 		break;
 
 	case UBX_MSG_INF_DEBUG:

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -715,50 +715,32 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	if (_mode == UBXMode::RoverWithStaticBaseUart2 || _mode == UBXMode::RoverWithMovingBase) {
 		UBX_DEBUG("Configuring UART2 for rover");
-		PX4_WARN("Configuring UART2 for rover");
-		{
-			cfg_valset_msg_size = initCfgValset();
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-			// heading output period 1 second
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART1, 1, cfg_valset_msg_size);
-			// enable RTCM input on uart2 + set baudrate
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-			cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
+		cfg_valset_msg_size = initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+		// heading output period 1 second
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_USB, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART1, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_USB, 1, cfg_valset_msg_size);
+		// enable RTCM input on uart2 + set baudrate
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
 
-			if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-				return -1;
-			}
-
-			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-				return -1;
-			}
+		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+			return -1;
 		}
 
-		PX4_WARN("Configuring USB for rover");
-		{
-			cfg_valset_msg_size = initCfgValset();
-			// heading output period 1 second
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_USB, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_USB, 1, cfg_valset_msg_size);
-
-			if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-				return -1;
-			}
-
-			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-				return -1;
-			}
+		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+			return -1;
 		}
-		PX4_WARN("OK: Configured USB for rover");
 
 	} else if (_mode == UBXMode::MovingBase) {
 		UBX_DEBUG("Configuring UART2 for moving base");

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1510,6 +1510,10 @@ GPSDriverUBX::payloadRxInit()
 			case UBX_MSG_RXM_SFRBX:
 				key_id = UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C;
 				break;
+
+			case UBX_MSG_NAV_TIMEGPS:
+				key_id = UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C;
+				break;
 			}
 
 			if (key_id != 0) {

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -715,32 +715,50 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	if (_mode == UBXMode::RoverWithStaticBaseUart2 || _mode == UBXMode::RoverWithMovingBase) {
 		UBX_DEBUG("Configuring UART2 for rover");
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-		// heading output period 1 second
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_USB, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART1, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_USB, 1, cfg_valset_msg_size);
-		// enable RTCM input on uart2 + set baudrate
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
+		PX4_WARN("Configuring UART2 for rover");
+		{
+			cfg_valset_msg_size = initCfgValset();
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+			// heading output period 1 second
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART1, 1, cfg_valset_msg_size);
+			// enable RTCM input on uart2 + set baudrate
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+			cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
-			return -1;
+			if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+				return -1;
+			}
+
+			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+				return -1;
+			}
 		}
 
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
-			return -1;
+		PX4_WARN("Configuring USB for rover");
+		{
+			cfg_valset_msg_size = initCfgValset();
+			// heading output period 1 second
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_USB, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_USB, 1, cfg_valset_msg_size);
+
+			if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+				return -1;
+			}
+
+			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+				return -1;
+			}
 		}
+		PX4_WARN("OK: Configured USB for rover");
 
 	} else if (_mode == UBXMode::MovingBase) {
 		UBX_DEBUG("Configuring UART2 for moving base");
@@ -755,6 +773,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_USB, 1, cfg_valset_msg_size);
 
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART2, 1, cfg_valset_msg_size);
@@ -808,6 +827,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART2, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART1, 0, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART2, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_USB, 1, cfg_valset_msg_size);
 
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1, 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1, cfg_valset_msg_size);
@@ -1070,18 +1090,17 @@ GPSDriverUBX::receive(unsigned timeout)
 	int handled = 0;
 
 	while (true) {
-		bool ready_to_return = _configured ? ((_got_posllh || _got_hpposllh) && _got_velned) : handled;
+		bool ready_to_return = _configured ? (_got_posllh && _got_velned) : handled;
 
 		/* return success if ready */
 		if (ready_to_return) {
 			_got_posllh = false;
-			_got_hpposllh = false;
 			_got_velned = false;
 			return handled;
 		}
 
 		/* Wait for only UBX_PACKET_TIMEOUT if something already received. */
-		int ret = read(buf, sizeof(buf), (_got_posllh || _got_hpposllh || _got_velned) ? UBX_PACKET_TIMEOUT : timeout);
+		int ret = read(buf, sizeof(buf), (_got_posllh || _got_velned) ? UBX_PACKET_TIMEOUT : timeout);
 
 		if (ret < 0) {
 			/* something went wrong when polling or reading */
@@ -1102,7 +1121,6 @@ GPSDriverUBX::receive(unsigned timeout)
 				if (buf[ret - 1] == 0xff) {
 					if (ready_to_return) {
 						_got_posllh = false;
-						_got_hpposllh = false;
 						_got_velned = false;
 						return handled;
 					}
@@ -1363,6 +1381,21 @@ GPSDriverUBX::payloadRxInit()
 
 		break;
 
+	case UBX_MSG_NAV_HPPOSLLH:
+		//PX4_WARN("case UBX_MSG_NAV_HPPOSLLH");
+		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_hpposllh_t)) {
+			PX4_WARN("case UBX_MSG_NAV_HPPOSLLH - wrong length");
+			_rx_state = UBX_RXMSG_ERROR_LENGTH;
+
+		} else if (!_configured) {
+			PX4_WARN("case UBX_MSG_NAV_HPPOSLLH - ignore if not _configured");
+			_rx_state = UBX_RXMSG_IGNORE;        // ignore if not _configured
+
+		}
+		//PX4_WARN("OK: case UBX_MSG_NAV_HPPOSLLH");
+
+		break;
+
 	case UBX_MSG_NAV_TIMEUTC:
 		if (_rx_payload_length != sizeof(ubx_payload_rx_nav_timeutc_t)) {
 			_rx_state = UBX_RXMSG_ERROR_LENGTH;
@@ -1473,6 +1506,7 @@ GPSDriverUBX::payloadRxInit()
 
 	case UBX_RXMSG_DISABLE:	// disable unexpected messages
 		UBX_DEBUG("ubx msg 0x%04x len %u unexpected", SWAP16((unsigned)_rx_msg), (unsigned)_rx_payload_length);
+		PX4_WARN("ubx msg 0x%04x len %u unexpected", SWAP16((unsigned)_rx_msg), (unsigned)_rx_payload_length);
 
 		if (_proto_ver_27_or_higher) {
 			uint32_t key_id = 0;
@@ -1519,11 +1553,13 @@ GPSDriverUBX::payloadRxInit()
 
 	case UBX_RXMSG_ERROR_LENGTH:	// error: invalid length
 		UBX_WARN("ubx msg 0x%04x invalid len %u", SWAP16((unsigned)_rx_msg), (unsigned)_rx_payload_length);
+		PX4_WARN("ubx msg 0x%04x invalid len %u", SWAP16((unsigned)_rx_msg), (unsigned)_rx_payload_length);
 		ret = -1;	// return error, abort handling this message
 		break;
 
 	default:	// invalid message state
 		UBX_WARN("ubx internal err1");
+		PX4_WARN("ubx internal err1");
 		ret = -1;	// return error, abort handling this message
 		break;
 	}
@@ -1872,13 +1908,16 @@ GPSDriverUBX::payloadRxDone()
 
 		_gps_position->satellites_used	= _buf.payload_rx_nav_pvt.numSV;
 
-		_gps_position->lat		= _buf.payload_rx_nav_pvt.lat;
-		_gps_position->lon		= _buf.payload_rx_nav_pvt.lon;
-		_gps_position->alt		= _buf.payload_rx_nav_pvt.hMSL;
-		_gps_position->alt_ellipsoid	= _buf.payload_rx_nav_pvt.height;
-
-		_gps_position->eph		= static_cast<float>(_buf.payload_rx_nav_pvt.hAcc) * 1e-3f;
-		_gps_position->epv		= static_cast<float>(_buf.payload_rx_nav_pvt.vAcc) * 1e-3f;
+		if(_gps_position->fix_type < 6)
+		{
+			// When RTK is active and solid, these values will be filled by HPPOSLLH:
+			_gps_position->lat		= _buf.payload_rx_nav_pvt.lat;
+			_gps_position->lon		= _buf.payload_rx_nav_pvt.lon;
+			_gps_position->alt		= _buf.payload_rx_nav_pvt.hMSL;
+			_gps_position->alt_ellipsoid	= _buf.payload_rx_nav_pvt.height;
+			_gps_position->eph		= static_cast<float>(_buf.payload_rx_nav_pvt.hAcc) * 1e-3f;
+			_gps_position->epv		= static_cast<float>(_buf.payload_rx_nav_pvt.vAcc) * 1e-3f;
+		}
 		_gps_position->s_variance_m_s	= static_cast<float>(_buf.payload_rx_nav_pvt.sAcc) * 1e-3f;
 
 		_gps_position->vel_m_s		= static_cast<float>(_buf.payload_rx_nav_pvt.gSpeed) * 1e-3f;
@@ -1935,10 +1974,10 @@ GPSDriverUBX::payloadRxDone()
 		_rate_count_vel++;
 		_rate_count_lat_lon++;
 
-		_got_posllh = true;
 		_got_velned = true;
-
+		_got_posllh = true;
 		ret = 1;
+
 		break;
 
 	case UBX_MSG_INF_DEBUG:
@@ -1976,23 +2015,36 @@ GPSDriverUBX::payloadRxDone()
 		break;
 
 	case UBX_MSG_NAV_HPPOSLLH:
-		PX4_WARN("Rx NAV-HPPOSLLH");
 		UBX_TRACE_RXMSG("Rx NAV-HPPOSLLH");
 
-		_gps_position->lat	= _buf.payload_rx_nav_hpposllh.lat;
-		_gps_position->lon	= _buf.payload_rx_nav_hpposllh.lon;
-		_gps_position->alt	= _buf.payload_rx_nav_hpposllh.hMSL;
-		_gps_position->eph	= static_cast<float>(_buf.payload_rx_nav_hpposllh.hAcc) * 1e-3f; // from mm to m
-		_gps_position->epv	= static_cast<float>(_buf.payload_rx_nav_hpposllh.vAcc) * 1e-3f; // from mm to m
-		//_gps_position->alt_ellipsoid = _buf.payload_rx_nav_hpposllh.height;
-		_gps_position->alt_ellipsoid = (_buf.payload_rx_nav_hpposllh.latHp << 16) + _buf.payload_rx_nav_hpposllh.lonHp;	// hide high precision components here
+		if(_buf.payload_rx_nav_hpposllh.flags == 0 && _gps_position->fix_type == 6)
+		{
+			_gps_position->lat	= _buf.payload_rx_nav_hpposllh.lat;  // regular precision components
+			_gps_position->lon	= _buf.payload_rx_nav_hpposllh.lon;
 
-		_gps_position->timestamp = gps_absolute_time();
+			_gps_position->lat_hp = _buf.payload_rx_nav_hpposllh.latHp;	// high precision components
+			_gps_position->lon_hp = _buf.payload_rx_nav_hpposllh.lonHp;
 
-		_rate_count_lat_lon++;
-		_got_hpposllh = true;
+			_gps_position->alt = _buf.payload_rx_nav_hpposllh.hMSL;
+			_gps_position->alt_ellipsoid = _buf.payload_rx_nav_hpposllh.height;
 
-		ret = 1;
+			_gps_position->alt_hp = _buf.payload_rx_nav_hpposllh.hMSLHp;	// high precision components of altitude
+			_gps_position->alt_ellipsoid_hp = _buf.payload_rx_nav_hpposllh.heightHp;
+
+			_gps_position->eph	= static_cast<float>(_buf.payload_rx_nav_hpposllh.hAcc) * 1e-4f; // from 0.1 mm to m
+			_gps_position->epv	= static_cast<float>(_buf.payload_rx_nav_hpposllh.vAcc) * 1e-4f; // from 0.1 mm to m
+
+			_gps_position->timestamp = gps_absolute_time();
+
+			_rate_count_lat_lon++;
+			_got_posllh = true;
+
+			ret = 1;
+
+			//PX4_WARN("HPPOSLLH: alt_el: 0x%08x (%d) h: %d eph: %f epv: %f hAcc: %d vAcc: %d",
+			//		 _gps_position->alt_ellipsoid, _gps_position->alt_ellipsoid, _buf.payload_rx_nav_hpposllh.height, (double)_gps_position->eph, (double)_gps_position->epv,
+			//		 _buf.payload_rx_nav_hpposllh.hAcc, _buf.payload_rx_nav_hpposllh.vAcc);
+		}
 		break;
 
 	case UBX_MSG_NAV_SOL:

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1962,8 +1962,8 @@ GPSDriverUBX::payloadRxDone()
 		_rate_count_vel++;
 		_rate_count_lat_lon++;
 
-		_got_velned = true;
 		_got_posllh = true;
+		_got_velned = true;
 		ret = 1;
 
 		break;

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1132,7 +1132,6 @@ private:
 
 	bool _configured{false};
 	bool _got_posllh{false};
-	bool _got_hpposllh{false};
 	bool _got_velned{false};
 	bool _proto_ver_27_or_higher{false}; ///< true if protocol version 27 or higher detected
 	bool _use_nav_pvt{false};

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -82,6 +82,7 @@
 #define UBX_ID_NAV_SOL        0x06
 #define UBX_ID_NAV_PVT        0x07
 #define UBX_ID_NAV_VELNED     0x12
+#define UBX_ID_NAV_TIMEGPS    0x20
 #define UBX_ID_NAV_HPPOSLLH   0x14
 #define UBX_ID_NAV_TIMEUTC    0x21
 #define UBX_ID_NAV_SVINFO     0x30
@@ -138,6 +139,7 @@
 #define UBX_MSG_NAV_VELNED    ((UBX_CLASS_NAV) | UBX_ID_NAV_VELNED << 8)
 #define UBX_MSG_NAV_HPPOSLLH  ((UBX_CLASS_NAV) | UBX_ID_NAV_HPPOSLLH << 8)
 #define UBX_MSG_NAV_TIMEUTC   ((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEUTC << 8)
+#define UBX_MSG_NAV_TIMEGPS   ((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEGPS << 8)
 #define UBX_MSG_NAV_SVINFO    ((UBX_CLASS_NAV) | UBX_ID_NAV_SVINFO << 8)
 #define UBX_MSG_NAV_SAT       ((UBX_CLASS_NAV) | UBX_ID_NAV_SAT << 8)
 #define UBX_MSG_NAV_STATUS    ((UBX_CLASS_NAV) | UBX_ID_NAV_STATUS << 8)
@@ -368,6 +370,7 @@
 #define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C  0x20910318
 #define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C  0x209102d6
 #define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C  0x20910303
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C   0x20910047
 
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1 0x2091008e
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART2 0x2091008f
@@ -924,7 +927,7 @@ typedef union {
 	ubx_payload_rx_mon_rf_t           payload_rx_mon_rf;
 	ubx_payload_rx_mon_ver_part1_t    payload_rx_mon_ver_part1;
 	ubx_payload_rx_mon_ver_part2_t    payload_rx_mon_ver_part2;
-	ubx_payload_rx_rxm_rtcm_t	  payload_rx_rxm_rtcm;
+	ubx_payload_rx_rxm_rtcm_t         payload_rx_rxm_rtcm;
 	ubx_payload_rx_ack_ack_t          payload_rx_ack_ack;
 	ubx_payload_rx_ack_nak_t          payload_rx_ack_nak;
 	ubx_payload_tx_cfg_prt_t          payload_tx_cfg_prt;

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -82,6 +82,7 @@
 #define UBX_ID_NAV_SOL        0x06
 #define UBX_ID_NAV_PVT        0x07
 #define UBX_ID_NAV_VELNED     0x12
+#define UBX_ID_NAV_HPPOSLLH   0x14
 #define UBX_ID_NAV_TIMEUTC    0x21
 #define UBX_ID_NAV_SVINFO     0x30
 #define UBX_ID_NAV_SAT        0x35
@@ -134,6 +135,7 @@
 #define UBX_MSG_NAV_DOP       ((UBX_CLASS_NAV) | UBX_ID_NAV_DOP << 8)
 #define UBX_MSG_NAV_PVT       ((UBX_CLASS_NAV) | UBX_ID_NAV_PVT << 8)
 #define UBX_MSG_NAV_VELNED    ((UBX_CLASS_NAV) | UBX_ID_NAV_VELNED << 8)
+#define UBX_MSG_NAV_HPPOSLLH  ((UBX_CLASS_NAV) | UBX_ID_NAV_HPPOSLLH << 8)
 #define UBX_MSG_NAV_TIMEUTC   ((UBX_CLASS_NAV) | UBX_ID_NAV_TIMEUTC << 8)
 #define UBX_MSG_NAV_SVINFO    ((UBX_CLASS_NAV) | UBX_ID_NAV_SVINFO << 8)
 #define UBX_MSG_NAV_SAT       ((UBX_CLASS_NAV) | UBX_ID_NAV_SAT << 8)
@@ -361,6 +363,10 @@
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART1 0x2091008e
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_UART2 0x2091008f
 #define UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_USB   0x20910090
+
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART1 0x20910034
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_UART2 0x20910035
+#define UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_USB   0x20910036
 
 #define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1  0x209102ff
 #define UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_1_UART1  0x20910382
@@ -858,10 +864,29 @@ typedef struct {
 	uint32_t    flags;
 } ubx_payload_rx_nav_relposned_t;
 
+/* NAV HPPOSLLH (protocol version 27+) */
+typedef struct {
+	uint8_t     version;         /**< message version (expected 0x00) */
+	uint8_t     reserved1[2];
+	int8_t      flags;           /**<  invalidLlh: 1 = Invalid lon, lat, height, hMSL, lonHp, latHp, heightHp and hMSLHp */
+	uint32_t    iTOW;            /**<  [ms] GPS time of week of the navigation epoch */
+	int32_t     lon;             /**<  [1e-7 deg] Longitude */
+	int32_t     lat;             /**<  [1e-7 deg] Latitude */
+	int32_t     height;          /**<  [mm] Height above Ellipsoid */
+	int32_t     hMSL;            /**<  [mm] Height above mean sea level */
+	int8_t      lonHp;           /**<  [1e-9 deg] Longitude high precision component, -99 to +99 */
+	int8_t      latHp;           /**<  [1e-9 deg] Latitude high precision component, -99 to +99 */
+	int8_t      heightHp;        /**<  [0.1 mm] high precision component of height above Ellipsoid, -9 to +9 */
+	int8_t      hMSLHp;          /**<  [0.1 mm] high precision component of height above mean sea level, -9 to +9 */
+	uint32_t    hAcc;            /**<  [0.1 mm] Horizontal Accuracy Estimate */
+	uint32_t    vAcc;            /**<  [0.1 mm] Vertical Accuracy Estimate */
+} ubx_payload_rx_nav_hpposllh_t;
+
 /* General message and payload buffer union */
 typedef union {
 	ubx_payload_rx_nav_pvt_t          payload_rx_nav_pvt;
 	ubx_payload_rx_nav_posllh_t       payload_rx_nav_posllh;
+	ubx_payload_rx_nav_hpposllh_t     payload_rx_nav_hpposllh;
 	ubx_payload_rx_nav_sol_t          payload_rx_nav_sol;
 	ubx_payload_rx_nav_dop_t          payload_rx_nav_dop;
 	ubx_payload_rx_nav_timeutc_t      payload_rx_nav_timeutc;
@@ -1107,6 +1132,7 @@ private:
 
 	bool _configured{false};
 	bool _got_posllh{false};
+	bool _got_hpposllh{false};
 	bool _got_velned{false};
 	bool _proto_ver_27_or_higher{false}; ///< true if protocol version 27 or higher detected
 	bool _use_nav_pvt{false};


### PR DESCRIPTION
**Currently** LAT/LON/ALT values come mostly from UBX_MSG_NAV_PVT message, which does not deliver high precision components to *_gps_position* ORB message (a.k.a. SensorGps.msg).

**This PR seeks** to add parsing of the MSG_NAV_HPPOSLLH message and delivering high precision components of the coordinates to the PX4 codebase.

My code works fine on my rover, removing random jerking  which was caused by low precision "rounding" of the coordinates. With centimeter accuracy my rover (lawnmower) moves smoothly and precisely, which is critical for agricultural vehicles.

I have dual antenna F9P configuration and also take advantage of precise heading (RELPOSNED).

Here is the code that utilizes the added fields:

```
// must be float64 (a.k.a. double) for RTK precision:
double f_lat = _sensor_gps_data.lat / 1.0e7 + _sensor_gps_data.lat_hp / 1.0e9;
double f_lon = _sensor_gps_data.lon / 1.0e7 + _sensor_gps_data.lon_hp / 1.0e9;

matrix::Vector2d cp(f_lat, f_lon);

PX4_INFO("Lat: %.12f  %.12f  Lon: %.12f  %.12f", f_lat, _global_pos.lat, f_lon, _global_pos.lon);

_current_position = cp;
``` 

I'd guess that the added components must be also passed to EKF2 for better estimates. It could also prioritize RTK precision data, when available.

**Note:**
The following block must be added to **PX4-Autopilot/msg/SensorGps.msg**, to generate *sensor_gps_s* structure:
```
...
int32 alt_ellipsoid          # Altitude in 1E-3 meters above Ellipsoid, (millimetres)

# RTK GPS high precision components:
int8  lat_hp                 # Latitude high precision component, -99 to +99 in 1E-9 degrees
int8  lon_hp                 # Longitude high precision component, -99 to +99 in 1E-9 degrees
int8  alt_hp                 # high precision component of altitude above mean sea level, -9 to +9 in 0.1 mm
int8  alt_ellipsoid_hp       # high precision component of altitude above Ellipsoid, -9 to +9 in 0.1 mm

float32 s_variance_m_s       # GPS speed accuracy estimate, (meters/sec)
...
```