### PR TITLE
ubx: ignore deprecated MON-HW message

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1413,8 +1413,9 @@ GPSDriverUBX::payloadRxInit()
 		break;		// unconditionally handle this message
 
 	case UBX_MSG_MON_HW:
-		if ((_rx_payload_length != sizeof(ubx_payload_rx_mon_hw_ubx6_t))	/* u-blox 6 msg format */
-		    && (_rx_payload_length != sizeof(ubx_payload_rx_mon_hw_ubx7_t))) {	/* u-blox 7+ msg format */
+		if ((_rx_payload_length != sizeof(ubx_payload_rx_mon_hw_ubx6_t))
+		    && (_rx_payload_length != sizeof(ubx_payload_rx_mon_hw_ubx7_t))
+		    && (_rx_payload_length != sizeof(ubx_payload_rx_mon_hw_deprecated_t))) {
 			_rx_state = UBX_RXMSG_ERROR_LENGTH;
 
 		} else if (!_configured) {
@@ -2216,6 +2217,10 @@ GPSDriverUBX::payloadRxDone()
 			_gps_position->jamming_indicator	= _buf.payload_rx_mon_hw_ubx7.jamInd;
 
 			ret = 1;
+			break;
+
+		case sizeof(ubx_payload_rx_mon_hw_deprecated_t):	/* u-blox 27+ deprecated, ignore */
+			ret = 0;
 			break;
 
 		default:		// unexpected payload size:

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -664,6 +664,10 @@ typedef struct {
 	uint32_t pullL;
 } ubx_payload_rx_mon_hw_ubx7_t;
 
+typedef struct {
+	uint8_t reserved0[56];
+} ubx_payload_rx_mon_hw_deprecated_t;
+
 /* Rx MON-RF (replaces MON-HW, protocol 27+) */
 typedef struct {
 	uint8_t version;
@@ -891,6 +895,7 @@ typedef union {
 	ubx_payload_rx_nav_velned_t       payload_rx_nav_velned;
 	ubx_payload_rx_mon_hw_ubx6_t      payload_rx_mon_hw_ubx6;
 	ubx_payload_rx_mon_hw_ubx7_t      payload_rx_mon_hw_ubx7;
+	ubx_payload_rx_mon_hw_deprecated_t ubx_payload_rx_mon_hw_deprecated;
 	ubx_payload_rx_mon_rf_t           payload_rx_mon_rf;
 	ubx_payload_rx_mon_ver_part1_t    payload_rx_mon_ver_part1;
 	ubx_payload_rx_mon_ver_part2_t    payload_rx_mon_ver_part2;


### PR DESCRIPTION
It turns out that the MON-HW message is sent with a shorter length with protocol version 34 (e.g. uBlox M10).

For reference, see the interface description:
https://content.u-blox.com/sites/default/files/u-blox%20M10-SPG-5.00_InterfaceDescription_UBX-20053845.pdf at page 104 of 184.

This means we don't need to print a warning about a wrong length, and can just ignore the packet.

The data that we are interested in is also sent in the MON-RF message and already parsed in the driver.