### PR TITLE
Fix unsupported message with NEO-M9N Ublox module.

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -665,7 +665,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfg_valset_msg_size = initCfgValset();
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
 
-	// There is no RTCM on M10
+	// There is no RTCM on M10 and M9* (except F9P)
 	if (_board != Board::u_blox10 && _board != Board::u_blox9) {
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C,

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -666,7 +666,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
 
 	// There is no RTCM on M10
-	if (_board != Board::u_blox10) {
+	if (_board != Board::u_blox10 && _board != Board::u_blox9) {
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C,
 			      _mode == UBXMode::RoverWithMovingBase || _mode == UBXMode::RoverWithMovingBaseUART1 ? 1 : 0,


### PR DESCRIPTION
The current GPS driver in the autopilot system contains an issue when attempting to initialize communication with the NEO-M9N UBLOX module, which is integrated within the [TFGPS01](https://github.com/ThunderFly-aerospace/TFGPS01/). During communication, the GPS driver receives NACK (negative acknowledgment) when trying to configure the following messages:

1. `UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C`
2. `UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C`

After a reading of the [NEO-M9N documentation](https://content.u-blox.com/sites/default/files/u-blox-M9-SPG-4.04_InterfaceDescription_UBX-21022436.pdf), i have discovered that these specific message types are not supported by the NEO-M9N receiver. Consequently, the GPS driver fails to establish proper communication with the module, leading to the inability to retrieve GPS data and compromising the autopilot's navigation and positioning capabilities.

**Testing**
The proposed changes have been tested using NEO-M9N and CUAV FMUv5. The GPS driver was successfully initialized, and the autopilot shows correct functionality in receiving GPS data after implementing the exception for these messages.

More detailed description is here: https://github.com/PX4/PX4-Autopilot/issues/21914