### PR TITLE
move NO_MKTIME compilation flags

### DIFF
--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -85,6 +85,7 @@ int GPSDriverAshtech::handleMessage(int len)
 	int ret = 0;
 
 	if ((memcmp(_rx_buffer + 3, "ZDA,", 3) == 0) && (uiCalcComma == 6)) {
+#ifndef NO_MKTIME
 		/*
 		UTC day, month, and year, and local time zone offset
 		An example of the ZDA message string is:
@@ -120,7 +121,6 @@ int GPSDriverAshtech::handleMessage(int len)
 
 		if (bufptr && *(++bufptr) != ',') { local_time_off_min = strtol(bufptr, &endp, 10); bufptr = endp; }
 
-
 		int ashtech_hour = static_cast<int>(ashtech_time / 10000);
 		int ashtech_minute = static_cast<int>((ashtech_time - ashtech_hour * 10000) / 100);
 		double ashtech_sec = static_cast<double>(ashtech_time - ashtech_hour * 10000 - ashtech_minute * 100);
@@ -137,7 +137,6 @@ int GPSDriverAshtech::handleMessage(int len)
 		timeinfo.tm_sec = int(ashtech_sec);
 		timeinfo.tm_isdst = 0;
 
-#ifndef NO_MKTIME
 		time_t epoch = mktime(&timeinfo);
 
 		if (epoch > GPS_EPOCH_SECS) {

--- a/src/mtk.cpp
+++ b/src/mtk.cpp
@@ -246,6 +246,7 @@ GPSDriverMTK::handleMessage(gps_mtk_packet_t &packet)
 	_gps_position->cog_rad = ((float)packet.heading) * M_DEG_TO_RAD_F * 1e-2f; //from deg *100 to rad
 	_gps_position->satellites_used = packet.satellites;
 
+#ifndef NO_MKTIME
 	/* convert time and date information to unix timestamp */
 	struct tm timeinfo = {};
 	uint32_t timeinfo_conversion_temp;
@@ -264,7 +265,6 @@ GPSDriverMTK::handleMessage(gps_mtk_packet_t &packet)
 
 	timeinfo.tm_isdst = 0;
 
-#ifndef NO_MKTIME
 
 	time_t epoch = mktime(&timeinfo);
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1922,6 +1922,7 @@ GPSDriverUBX::payloadRxDone()
 		if ((_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_VALIDDATE)
 		    && (_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_VALIDTIME)
 		    && (_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_FULLYRESOLVED)) {
+#ifndef NO_MKTIME
 			/* convert to unix timestamp */
 			tm timeinfo{};
 			timeinfo.tm_year	= _buf.payload_rx_nav_pvt.year - 1900;
@@ -1931,7 +1932,7 @@ GPSDriverUBX::payloadRxDone()
 			timeinfo.tm_min		= _buf.payload_rx_nav_pvt.min;
 			timeinfo.tm_sec		= _buf.payload_rx_nav_pvt.sec;
 
-#ifndef NO_MKTIME
+
 			time_t epoch = mktime(&timeinfo);
 
 			if (epoch > GPS_EPOCH_SECS) {
@@ -2057,6 +2058,7 @@ GPSDriverUBX::payloadRxDone()
 		UBX_TRACE_RXMSG("Rx NAV-TIMEUTC");
 
 		if (_buf.payload_rx_nav_timeutc.valid & UBX_RX_NAV_TIMEUTC_VALID_VALIDUTC) {
+#ifndef NO_MKTIME
 			// convert to unix timestamp
 			tm timeinfo {};
 			timeinfo.tm_year	= _buf.payload_rx_nav_timeutc.year - 1900;
@@ -2066,7 +2068,7 @@ GPSDriverUBX::payloadRxDone()
 			timeinfo.tm_min		= _buf.payload_rx_nav_timeutc.min;
 			timeinfo.tm_sec		= _buf.payload_rx_nav_timeutc.sec;
 			timeinfo.tm_isdst	= 0;
-#ifndef NO_MKTIME
+
 			time_t epoch = mktime(&timeinfo);
 
 			// only set the time if it makes sense


### PR DESCRIPTION
I had compilation errors when compiling with NO_MKTIME defined, for a number of reasons:

- `struct tm` not defined
- various variables set but not used, e.g. `ashtech_sec` in ashtech.cpp

by moving the NO_MKTIME conditional compilation flag, I removed these compilation errors, and also I believe skip unnecessary packet decoding, when the results of the decoding was not being used without `mktime`

I don't have the ability to test these changes on a PX4 target that has NO_MKTIME defined.