### PR TITLE
Add Option to Toggle Automatic Receiver Setup

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -198,6 +198,7 @@ public:
 		OutputMode output_mode;
 		GNSSSystemsMask gnss_systems;
 		InterfaceProtocolsMask interface_protocols;
+		bool configure_device = true;					///< automatically configure the attached receiver
 	};
 
 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -78,6 +78,11 @@ GPSDriverSBF::~GPSDriverSBF()
 
 int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 {
+	if (!config.configure_device) {
+		_configured = true;
+		return 0;
+	}
+
 	_configured = false;
 
 	setBaudrate(SBF_TX_CFG_PRT_BAUDRATE);

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -78,11 +78,6 @@ GPSDriverSBF::~GPSDriverSBF()
 
 int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 {
-	if (!config.configure_device) {
-		_configured = true;
-		return 0;
-	}
-
 	_configured = false;
 
 	setBaudrate(SBF_TX_CFG_PRT_BAUDRATE);
@@ -145,6 +140,11 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 	} else {
 		SBF_WARN("No COM port detected")
 		return -1;
+	}
+
+	if (!config.configure_device) {
+		_configured = true;
+		return 0;
 	}
 
 	// Delete all sbf outputs on current COM port to remove clutter data


### PR DESCRIPTION
This adds an option to disable automatic setup of the attached receiver during the configuration. It is only implemented by the SBF driver for now. Other drivers can implement it if they want. This is linked to another PR in the PX4-Autopilot project to add a parameter that lets users disable automatic driver configuration.

@SeptentrioGNSS