### PR TITLE
sbf: fix RTCM base functionality

### DIFF
--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -150,12 +150,14 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 		return -1; // connection and/or baudrate detection failed
 	}
 
-	// Set baut rate
-	snprintf(msg, sizeof(msg), SBF_CONFIG_BAUDRATE, com_port, baudrate);
+	// Set baudrate, unless we're connected over USB
+	if (strncmp(com_port, "USB1", 4) != 0 && strncmp(com_port, "USB2", 4) != 0) {
+		snprintf(msg, sizeof(msg), SBF_CONFIG_BAUDRATE, com_port, baudrate);
 
-	if (!sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT)) {
-		SBF_DEBUG("Connection and/or baudrate detection failed (SBF_CONFIG_BAUDRATE)");
-		return -1; // connection and/or baudrate detection failed
+		if (!sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT)) {
+			SBF_DEBUG("Connection and/or baudrate detection failed (SBF_CONFIG_BAUDRATE)");
+			return -1; // connection and/or baudrate detection failed
+		}
 	}
 
 	// Flush input and wait for at least 50 ms silence

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -235,6 +235,8 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 			sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT);
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC1, SBF_CONFIG_TIMEOUT);
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC2, SBF_CONFIG_TIMEOUT);
+		} else {
+			sendMessageAndWaitForAck(SBF_CONFIG_RTCM, SBF_CONFIG_TIMEOUT);
 		}
 	}
 


### PR DESCRIPTION
This contains two fixes required to use the Septentrio Mosaic as an RTK base connected via USB to QGroundControl.

- Don't try to change baudrate of USB ports.
- Actually configure RTCM. This must have been lost somewhere in the past.

See commits for details.

Tested using the [Holybro H-RTK mosaic-H](https://holybro.com/products/h-rtk-mosaic)

FYI @SeptentrioGNSS and @vincentpoont2