### PR TITLE
Add configuration for receiver logging

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -194,10 +194,27 @@ public:
 		I2C_OUT_PROT_RTCM3X = 1 << 5
 	};
 
+	enum class LoggingLevel : int8_t {
+		LITE = 0,
+		BASIC,
+		DEFAULT,
+		FULL
+	};
+
+	/**
+	 * GNSS receiver logging configuration.
+	 */
+	struct LoggingConfig {
+		float frequency;
+		LoggingLevel level;
+		bool overwrite;
+	};
+
 	struct GPSConfig {
 		OutputMode output_mode;
 		GNSSSystemsMask gnss_systems;
 		InterfaceProtocolsMask interface_protocols;
+		LoggingConfig logging_configuration;
 	};
 
 

--- a/src/sbf.h
+++ b/src/sbf.h
@@ -65,6 +65,27 @@
 
 #define SBF_CONFIG "setSBFOutput, Stream1, %s, PVTGeodetic+VelCovGeodetic+DOP+AttEuler+AttCovEuler, msec100\n"
 
+/**
+ * Configure logging on stream 4.
+ * The first argument %s defines overwrite behavior.
+ * The second argument %s are the blocks that should be output.
+ * The third argument %s is the frequency at which they need to be output.
+ */
+#define SBF_CONFIG_LOGGING "setSBFOutput, Stream4, DSK1, %s%s, %s\n"
+
+#define SBF_LOGGING_LITE    "Comment+ReceiverStatus";
+#define SBF_LOGGING_BASIC   "Comment+ReceiverStatus+PostProcess+Event";
+#define SBF_LOGGING_DEFAULT "Comment+ReceiverStatus+PostProcess+Event+Support";
+#define SBF_LOGGING_FULL    "Comment+ReceiverStatus+PostProcess+Event+Support+BBSamples";
+
+#define SBF_0_1_HZ  "sec10";
+#define SBF_0_2_HZ  "sec5";
+#define SBF_0_5_HZ  "sec2";
+#define SBF_1_0_HZ  "sec1";
+#define SBF_2_0_HZ  "msec500";
+#define SBF_5_0_HZ  "msec200";
+#define SBF_10_0_HZ "msec100";
+#define SBF_20_0_HZ "msec50";
 
 #define SBF_CONFIG_RTCM "" \
 	"setDataInOut, USB1, Auto, RTCMv3+SBF\n" \


### PR DESCRIPTION
This adds some new configuration that can be used to set up the receiver to log data to its internal disk. This is part of [a feature for PX4](https://github.com/PX4/PX4-Autopilot/pull/22874) to add parameters that enable logging setup by the user, without having to do it manually on the receiver. It is currently only implemented for the SBF driver. The implementation is kept generic to make sure other drivers can implement it as well.