### PR TITLE
sbf: Delete unnecessary processes

### DIFF
--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -380,7 +380,6 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 
 		} else {
 			// expecting more payload, stay in state SBF_DECODE_PAYLOAD
-			ret = 0;
 
 		}
 


### PR DESCRIPTION
When RET is 0, the description is reset to 0.
I do not think it is necessary.