### PR TITLE
UBX UART TX packet consolidation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+insert_final_newline = false
+
+[{*.{c,cpp,cc,h,hpp},CMakeLists.txt}]
+indent_style = tab
+tab_width = 8
+# Not in the official standard, but supported by many editors
+max_line_length = 120

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -150,12 +150,14 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 		return -1; // connection and/or baudrate detection failed
 	}
 
-	// Set baut rate
-	snprintf(msg, sizeof(msg), SBF_CONFIG_BAUDRATE, com_port, baudrate);
+	// Set baudrate, unless we're connected over USB
+	if (strncmp(com_port, "USB1", 4) != 0 && strncmp(com_port, "USB2", 4) != 0) {
+		snprintf(msg, sizeof(msg), SBF_CONFIG_BAUDRATE, com_port, baudrate);
 
-	if (!sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT)) {
-		SBF_DEBUG("Connection and/or baudrate detection failed (SBF_CONFIG_BAUDRATE)");
-		return -1; // connection and/or baudrate detection failed
+		if (!sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT)) {
+			SBF_DEBUG("Connection and/or baudrate detection failed (SBF_CONFIG_BAUDRATE)");
+			return -1; // connection and/or baudrate detection failed
+		}
 	}
 
 	// Flush input and wait for at least 50 ms silence

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -235,6 +235,8 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 			sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT);
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC1, SBF_CONFIG_TIMEOUT);
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC2, SBF_CONFIG_TIMEOUT);
+		} else {
+			sendMessageAndWaitForAck(SBF_CONFIG_RTCM, SBF_CONFIG_TIMEOUT);
 		}
 	}
 

--- a/src/sbf.h
+++ b/src/sbf.h
@@ -65,19 +65,11 @@
 
 #define SBF_CONFIG "setSBFOutput, Stream1, %s, PVTGeodetic+VelCovGeodetic+DOP+AttEuler+AttCovEuler, msec100\n"
 
+#define SBF_CONFIG_DISABLE_OUTPUT "setDataInOut,%s%d,,-RTCMv3\n"
 
 #define SBF_CONFIG_RTCM "" \
-	"setDataInOut, USB1, Auto, RTCMv3+SBF\n" \
-	"setPVTMode, Rover, All, auto\n" \
-	"setSatelliteTracking, All\n" \
-	"setSatelliteUsage, All\n" \
-	"setElevationMask, All, 10\n" \
-	"setReceiverDynamics, Moderate, Automotive\n" \
-	"setSBFOutput, Stream1, DSK1, Support, msec100\n" \
-	"setSBFOutput, Stream2, USB1, DOP+VelCovGeodetic, sec1\n" \
-	"setSBFOutput, Stream3, USB1, PVTGeodetic, msec200\n" \
-	"setFileNaming, DSK1, Incremental\n" \
-	"setFileNaming, DSK1, , 'px4rtcm'\n"
+	"setDataInOut, USB1, Auto, RTCMv3\n" \
+	"setPVTMode, Static, All, auto\n"
 
 #define SBF_CONFIG_RTCM_STATIC1 "" \
 	"setReceiverDynamics, Low, Static\n"

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2553,16 +2553,36 @@ GPSDriverUBX::sendMessage(const uint16_t msg, const uint8_t *payload, const uint
 		calcChecksum(payload, length, &checksum);
 	}
 
-	// Send message
-	if (write((void *)&header, sizeof(header)) != sizeof(header)) {
+	// Figure out total packet length and make sure there is enough buffer space
+	// available for it
+	int total_packet_length = (int)(sizeof(ubx_header_t) + sizeof(ubx_checksum_t));
+
+	if (payload) {
+		total_packet_length += (int) length;
+	}
+
+	if (total_packet_length > (int) sizeof(_tx_packet)) {
+		UBX_DEBUG("Tx msg too large: %u", total_packet_length);
 		return false;
 	}
 
-	if (payload && write((void *)payload, length) != length) {
-		return false;
+	// Coalesce the packet elements into the transmission buffer. Some UARTs have
+	// too long of a period in between transmissions and it will cause the GPS
+	// unit to assume that the packet was lost if it is sent in multiple parts
+	// (e.g. Send header, then payload, then checksum)
+	uint8_t *b = _tx_packet;
+	memcpy(b, &header, sizeof(header));
+	b += sizeof(header);
+
+	if (payload) {
+		memcpy(b, payload, length);
+		b += length;
 	}
 
-	if (write((void *)&checksum, sizeof(checksum)) != sizeof(checksum)) {
+	memcpy(b, &checksum, sizeof(checksum));
+
+	// Send the packet
+	if (write((void *) _tx_packet, total_packet_length) != total_packet_length) {
 		return false;
 	}
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1173,6 +1173,8 @@ private:
 	uint16_t _rx_payload_index{0};
 	uint16_t _rx_payload_length{0};
 
+	uint8_t _tx_packet[sizeof(ubx_header_t) + sizeof(ubx_buf_t) + sizeof(ubx_checksum_t)];
+
 	uint32_t _ubx_version{0};
 
 	uint64_t _last_timestamp_time{0};


### PR DESCRIPTION
Added packet consolidation to UBX driver UART transmissions so that it sends each packet as a single transmission instead of as 3 separate ones (header, payload, and checksum). This is because on the VOXL 2 SLPI UART there is too much time between sequential transmissions that the GPS endpoint gives up and considers the packet lost before all portions can be sent.