### PR TITLE
Fix Receiver Port Detection in the Septentrio Driver

### DIFF
--- a/src/sbf.h
+++ b/src/sbf.h
@@ -377,6 +377,15 @@ public:
 
 	int receive(unsigned timeout) override;
 
+	/**
+	 * @brief Try to detect the serial port used on the receiver side.
+	 *
+	 * @param port_name A string with a length of 5 to store the result
+	 *
+	 * @return `PX4_OK` on success, `PX4_ERROR` on error
+	*/
+	int detectSerialPort(char *const port_name);
+
 	int configure(unsigned &baudrate, const GPSConfig &config) override;
 
 	int reset(GPSRestartType restart_type) override;


### PR DESCRIPTION
This fixes an issue which can prevent PX4 autopilot from recognizing the receiver port, sometimes leading to a failure to configure the driver or long attempts before it finally works. The current official release of PX4 autopilot is impacted by this issue. Currently work is being done on a new driver for Septentrio which would live in-tree (https://github.com/PX4/PX4-Autopilot/pull/22904), so I'm making this one against the release branch only. If it needs to go in the main branch as well, I can also make a pull request for that.