### PR TITLE
ubx.h: Removed double access specifier

### DIFF
--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1020,9 +1020,6 @@ public:
 	const Board &board() const { return _board; }
 
 private:
-
-private:
-
 	int activateRTCMOutput(bool reduce_update_rate);
 
 	/**


### PR DESCRIPTION
Duplicated private access specifier removed