### PR TITLE
ubx: fix overflow

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1528,7 +1528,7 @@ GPSDriverUBX::payloadRxInit()
 		break;
 
 	case UBX_MSG_RXM_RTCM:
-		if (_rx_payload_length < sizeof(ubx_payload_rx_rxm_rtcm_t)) {
+		if (_rx_payload_length != sizeof(ubx_payload_rx_rxm_rtcm_t)) {
 			_rx_state = UBX_RXMSG_ERROR_LENGTH;
 
 		} else if (!_configured) {

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -719,6 +719,7 @@ typedef struct {
 	uint8_t  flags;
 	uint16_t subType;
 	uint16_t refStationID;
+	uint16_t msgType;
 } ubx_payload_rx_rxm_rtcm_t;
 
 /* Rx ACK-ACK */


### PR DESCRIPTION
While using a F9P with RTK, the parser suddenly got stuck in the RTCM parsing, due to `_decode_state` having an invalid state (out of the enum range). This causes a GPS driver restart, which causes a delay in receiving GPS data.

This was due to an overflow of the variable: `_buf` which is stored before `_decode_state` in memory:
```
	ubx_buf_t               _buf{};
	ubx_decode_state_t      _decode_state{};
```

Debugging showed, that an invalid length was parsed which is only partly checked in case of `UBX_MSG_RXM_RTCM`.
As that message has a fixed length, the easiest option is to directly check against the expected length.