### PR TITLE
Improve RTCM3 parsing performance

### DIFF
--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -831,6 +831,16 @@ int GPSDriverAshtech::parseChar(uint8_t b)
 {
 	int iRet = 0;
 
+	if (_rtcm_parsing) {
+		if (_rtcm_parsing->addByte(b)) {
+			ASH_DEBUG("got RTCM message with length %i", (int)_rtcm_parsing->messageLength());
+			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
+			decodeInit();
+			_rtcm_parsing->reset();
+			return iRet;
+		}
+	}
+
 	switch (_decode_state) {
 	/* First, look for sync1 */
 	case NMEADecodeState::uninit:
@@ -887,15 +897,6 @@ int GPSDriverAshtech::parseChar(uint8_t b)
 			decodeInit();
 		}
 		break;
-	}
-
-	if (_rtcm_parsing && iRet <= 0) {
-		if (_rtcm_parsing->addByte(b)) {
-			ASH_DEBUG("got RTCM message with length %i", (int)_rtcm_parsing->messageLength());
-			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
-			decodeInit();
-			_rtcm_parsing->reset();
-		}
 	}
 
 	return iRet;

--- a/src/ashtech.h
+++ b/src/ashtech.h
@@ -85,8 +85,7 @@ private:
 		uninit,
 		got_sync1,
 		got_asteriks,
-		got_first_cs_byte,
-		decode_rtcm3
+		got_first_cs_byte
 	};
 
 	/**

--- a/src/femtomes.cpp
+++ b/src/femtomes.cpp
@@ -306,6 +306,16 @@ int GPSDriverFemto::parseChar(uint8_t temp)
 {
 	int iRet = 0;
 
+	if (_rtcm_parsing) {
+		if (_rtcm_parsing->addByte(temp)) {
+			FEMTO_DEBUG("Femto: got RTCM message with length %i", (int)_rtcm_parsing->messageLength())
+			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
+			decodeInit();
+			_rtcm_parsing->reset();
+			return iRet;
+		}
+	}
+
 	if (_output_mode == OutputMode::GPS) {
 
 		switch (_decode_state) {
@@ -480,15 +490,6 @@ int GPSDriverFemto::parseChar(uint8_t temp)
 			break;
 		}
 
-	}
-
-	if (_rtcm_parsing && iRet <= 0) {
-		if (_rtcm_parsing->addByte(temp)) {
-			FEMTO_DEBUG("Femto: got RTCM message with length %i", (int)_rtcm_parsing->messageLength())
-			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
-			decodeInit();
-			_rtcm_parsing->reset();
-		}
 	}
 
 	return iRet;

--- a/src/femtomes.h
+++ b/src/femtomes.h
@@ -154,8 +154,6 @@ enum class FemtoDecodeState {
 	pream_nmea_got_sync1,           /**< NMEA Frame '$' */
 	pream_nmea_got_asteriks,        /**< NMEA Frame '*' */
 	pream_nmea_got_first_cs_byte,   /**< NMEA Frame cs first byte */
-
-	decode_rtcm3                    /**< Frame rtcm3 */
 };
 
 class GPSDriverFemto : public GPSBaseStationSupport

--- a/src/nmea.cpp
+++ b/src/nmea.cpp
@@ -1096,6 +1096,16 @@ int GPSDriverNMEA::parseChar(uint8_t b)
 {
 	int iRet = 0;
 
+	if (_rtcm_parsing) {
+		if (_rtcm_parsing->addByte(b)) {
+			NMEA_DEBUG("got RTCM message with length %i", (int)_rtcm_parsing->messageLength());
+			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
+			decodeInit();
+			_rtcm_parsing->reset();
+			return iRet;
+		}
+	}
+
 	switch (_decode_state) {
 	/* First, look for sync1 */
 	case NMEADecodeState::uninit:
@@ -1151,15 +1161,6 @@ int GPSDriverNMEA::parseChar(uint8_t b)
 			decodeInit();
 		}
 		break;
-	}
-
-	if (_rtcm_parsing && iRet <= 0) {
-		if (_rtcm_parsing->addByte(b)) {
-			NMEA_DEBUG("got RTCM message with length %i", (int)_rtcm_parsing->messageLength());
-			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
-			decodeInit();
-			_rtcm_parsing->reset();
-		}
 	}
 
 	return iRet;

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -79,8 +79,7 @@ private:
 		uninit,
 		got_sync1,
 		got_asteriks,
-		got_first_cs_byte,
-		decode_rtcm3
+		got_first_cs_byte
 	};
 
 	void decodeInit(void);

--- a/src/rtcm.h
+++ b/src/rtcm.h
@@ -43,6 +43,12 @@
 class RTCMParsing
 {
 public:
+	enum class ParserStatus : uint8_t {
+		Failure,
+		ExpectingMore,
+		Finished
+	};
+
 	RTCMParsing();
 	~RTCMParsing();
 
@@ -54,17 +60,21 @@ public:
 	/**
 	 * add a byte to the message
 	 * @param b
-	 * @return true if message complete (use @message to get it)
+	 * @return ParserStatus::Finished, if a message is complete (use @message to get it). The user needs to reset the parser.
+	 *	ParserStatus::ExpectingMore, if the message is not complete yet and more data is needed.
+	 *	ParserStatus::Failure, if an error occured. The user needs to reset the parser.
 	 */
-	bool addByte(uint8_t b);
+	ParserStatus addByte(uint8_t b);
 
 	uint8_t *message() const { return _buffer; }
 	uint16_t messageLength() const { return _pos; }
 	uint16_t messageId() const { return (_buffer[3] << 4) | (_buffer[4] >> 4); }
 
 private:
+	uint32_t crc24(const uint8_t *buffer, const uint16_t len);
+
 	uint8_t			*_buffer{nullptr};
 	uint16_t		_buffer_len{};
 	uint16_t		_pos{};						///< next position in buffer
-	uint16_t		_message_length{};					///< message length without header & CRC (both 3 bytes)
+	uint16_t		_message_length{};				///< message length without header & CRC (both 3 bytes)
 };

--- a/src/rtcm.h
+++ b/src/rtcm.h
@@ -43,12 +43,6 @@
 class RTCMParsing
 {
 public:
-	enum class ParserStatus : uint8_t {
-		Failure,
-		ExpectingMore,
-		Finished
-	};
-
 	RTCMParsing();
 	~RTCMParsing();
 
@@ -59,12 +53,11 @@ public:
 
 	/**
 	 * add a byte to the message
-	 * @param b
-	 * @return ParserStatus::Finished, if a message is complete (use @message to get it). The user needs to reset the parser.
-	 *	ParserStatus::ExpectingMore, if the message is not complete yet and more data is needed.
-	 *	ParserStatus::Failure, if an error occured. The user needs to reset the parser.
+	 * @param b byte to add
+	 * @return true, if a message is complete (use @message to get it). The user needs to reset the parser in this case.
+	 * 	false, if more data is needed or the parser failed. In this case no resetting of the parser is needed.
 	 */
-	ParserStatus addByte(uint8_t b);
+	bool addByte(uint8_t b);
 
 	uint8_t *message() const { return _buffer; }
 	uint16_t messageLength() const { return _pos; }
@@ -77,4 +70,5 @@ private:
 	uint16_t		_buffer_len{};
 	uint16_t		_pos{};						///< next position in buffer
 	uint16_t		_message_length{};				///< message length without header & CRC (both 3 bytes)
+	bool			_preamble_received{false};
 };

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -363,6 +363,16 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 {
 	int ret = 0;
 
+	if (_rtcm_parsing) {
+		if (_rtcm_parsing->addByte(b)) {
+			SBF_DEBUG("got RTCM message with length %i", (int) _rtcm_parsing->messageLength());
+			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
+			decodeInit();
+			_rtcm_parsing->reset();
+			return ret;
+		}
+	}
+
 	switch (_decode_state) {
 
 	// Expecting Sync1
@@ -401,7 +411,7 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 		} else if (ret > 0) {
 			ret = payloadRxDone(); // finish payload processing
 
-			if (_rtcm_parsing && ret > 0) {
+			if (_rtcm_parsing) {
 				_rtcm_parsing->reset();
 			}
 
@@ -416,15 +426,6 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 
 	default:
 		break;
-	}
-
-	if (_rtcm_parsing && ret <= 0) {
-		if (_rtcm_parsing->addByte(b)) {
-			SBF_DEBUG("got RTCM message with length %i", (int) _rtcm_parsing->messageLength());
-			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
-			decodeInit();
-			_rtcm_parsing->reset();
-		}
 	}
 
 	return ret;

--- a/src/sbf.h
+++ b/src/sbf.h
@@ -345,8 +345,7 @@ uint8_t msg_revision:
 typedef enum {
 	SBF_DECODE_SYNC1 = 0,
 	SBF_DECODE_SYNC2,
-	SBF_DECODE_PAYLOAD,
-	SBF_DECODE_RTCM3
+	SBF_DECODE_PAYLOAD
 } sbf_decode_state_t;
 
 class GPSDriverSBF : public GPSBaseStationSupport

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1205,6 +1205,15 @@ GPSDriverUBX::parseChar(const uint8_t b)
 {
 	int ret = 0;
 
+	if (_rtcm_parsing) {
+		if (_rtcm_parsing->addByte(b)) {
+			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
+			decodeInit();
+			_rtcm_parsing->reset();
+			return ret;
+		}
+	}
+
 	switch (_decode_state) {
 
 	/* Expecting Sync1 */
@@ -1326,7 +1335,7 @@ GPSDriverUBX::parseChar(const uint8_t b)
 		} else {
 			ret = payloadRxDone();	// finish payload processing
 
-			if (_rtcm_parsing && ret > 0) {
+			if (_rtcm_parsing) {
 				_rtcm_parsing->reset();
 			}
 		}
@@ -1336,14 +1345,6 @@ GPSDriverUBX::parseChar(const uint8_t b)
 
 	default:
 		break;
-	}
-
-	if (_rtcm_parsing && ret <= 0) {
-		if (_rtcm_parsing->addByte(b)) {
-			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
-			decodeInit();
-			_rtcm_parsing->reset();
-		}
 	}
 
 	return ret;

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -310,6 +310,13 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 		}
 	}
 
+	if (_output_mode == OutputMode::GPSAndRTCM || _output_mode == OutputMode::RTCM || _mode == UBXMode::MovingBaseUART1) {
+		if (!_rtcm_parsing) {
+			_rtcm_parsing = new RTCMParsing();
+		}
+
+		_rtcm_parsing->reset();
+	}
 
 	if (_output_mode == OutputMode::RTCM) {
 		// RTCM mode force stationary dynamic model
@@ -1205,14 +1212,6 @@ GPSDriverUBX::parseChar(const uint8_t b)
 		if (b == UBX_SYNC1) {	// Sync1 found --> expecting Sync2
 			UBX_TRACE_PARSER("A");
 			_decode_state = UBX_DECODE_SYNC2;
-
-		} else if (b == RTCM3_PREAMBLE && _rtcm_parsing) {
-			UBX_TRACE_PARSER("RTCM");
-			_decode_state = UBX_DECODE_RTCM3;
-
-			if (_rtcm_parsing->addByte(b) != RTCMParsing::ParserStatus::ExpectingMore) {
-				decodeInit();
-			}
 		}
 
 		break;
@@ -1326,34 +1325,25 @@ GPSDriverUBX::parseChar(const uint8_t b)
 
 		} else {
 			ret = payloadRxDone();	// finish payload processing
+
+			if (_rtcm_parsing && ret > 0) {
+				_rtcm_parsing->reset();
+			}
 		}
 
 		decodeInit();
 		break;
 
-	case UBX_DECODE_RTCM3: {
-			RTCMParsing::ParserStatus parser_status = _rtcm_parsing->addByte(b);
-
-			switch (parser_status) {
-			case RTCMParsing::ParserStatus::Finished:
-				//UBX_DEBUG("got RTCM message with length %i", static_cast<int>(_rtcm_parsing->messageLength()));
-				gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
-				decodeInit();
-				break;
-
-			case RTCMParsing::ParserStatus::Failure:
-				UBX_DEBUG("rtcm3 parsing err");
-				decodeInit();
-				break;
-
-			default:
-				break;
-			}
-		}
-		break;
-
 	default:
 		break;
+	}
+
+	if (_rtcm_parsing && ret <= 0) {
+		if (_rtcm_parsing->addByte(b)) {
+			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
+			decodeInit();
+			_rtcm_parsing->reset();
+		}
 	}
 
 	return ret;
@@ -2503,16 +2493,6 @@ GPSDriverUBX::decodeInit()
 	_rx_ck_b = 0;
 	_rx_payload_length = 0;
 	_rx_payload_index = 0;
-
-	if (_output_mode == OutputMode::GPSAndRTCM || _output_mode == OutputMode::RTCM || _mode == UBXMode::MovingBaseUART1) {
-		if (!_rtcm_parsing) {
-			_rtcm_parsing = new RTCMParsing();
-		}
-
-		if (_rtcm_parsing) {
-			_rtcm_parsing->reset();
-		}
-	}
 }
 
 void

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -957,8 +957,6 @@ typedef enum {
 	UBX_DECODE_PAYLOAD,
 	UBX_DECODE_CHKSUM1,
 	UBX_DECODE_CHKSUM2,
-
-	UBX_DECODE_RTCM3
 } ubx_decode_state_t;
 
 /* Rx message state */


### PR DESCRIPTION
### Solved Problem
This is the first follow up to: https://github.com/PX4/PX4-Autopilot/pull/24491. The NAV + RTCM3 parser can block each other as both parsers are integrated into the same state machine. This can cause significant delay until the parser gets in sync again.

As can be seen in the attached screenshots, the remaining timeout is in general higher now and the deepest drop is not as low as before. This was the worst case scenario of many tests.

#### Worst without change
![Screenshot from 2025-03-18 16-38-44](https://github.com/user-attachments/assets/23821df4-1e0b-4eb3-bd70-b074a00409b9)

#### Worst with change
![Screenshot from 2025-03-18 16-39-07](https://github.com/user-attachments/assets/ccb78aac-b706-41e5-bb58-210a0a3c08f5)



### Solution
- Forward input data to both NAV + RTCM3 parser and keep their states separate, so they can not block each other
- Use CRC24 to verify if RTCM3 data is valid before forwarding it to the callback
- When either NAV or RTCM3 parsing is successful, reset both parsers to start sync again

I would like to keep the increased timeout until all remaining drops are removed, which will be done in follow-up PRs.

### Testing
- Tested with and without RTK on the bench
- Checked `gps_dump` data to ensure PPK still works