### PR TITLE
Improve base station configuration

### DIFF
--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,10 +57,10 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
+#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
 
 /**** Warning macros, disable to save memory */
-#define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
+#define SBF_WARN(...)        {/*GPS_WARN(__VA_ARGS__);*/}
 #define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,
@@ -226,21 +226,33 @@ int GPSDriverSBF::configure(unsigned &baudrate, const GPSConfig &config)
 		_rtcm_parsing->reset();
 	}
 
+	sendMessageAndWaitForAck(SBF_CONFIG_OUTPUT_RTCM3, SBF_CONFIG_TIMEOUT);
+	
 	if (_output_mode == OutputMode::RTCM) {
-		if (_base_settings.type == BaseSettingsType::fixed_position) {
+		switch(_base_settings.type){
+		case(BaseSettingsType::fixed_position):
 			snprintf(msg, sizeof(msg), SBF_CONFIG_RTCM_STATIC_COORDINATES,
-				 _base_settings.settings.fixed_position.latitude,
-				 _base_settings.settings.fixed_position.longitude,
-				 static_cast<double>(_base_settings.settings.fixed_position.altitude));
+				_base_settings.settings.fixed_position.latitude,
+				_base_settings.settings.fixed_position.longitude,
+				static_cast<double>(_base_settings.settings.fixed_position.altitude));
 			sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT);
+			
 			snprintf(msg, sizeof(msg), SBF_CONFIG_RTCM_STATIC_OFFSET, 0.0, 0.0, 0.0);
 			sendMessageAndWaitForAck(msg, SBF_CONFIG_TIMEOUT);
+			
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC1, SBF_CONFIG_TIMEOUT);
 			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATIC2, SBF_CONFIG_TIMEOUT);
+			break;
 
-		} else {
-			sendMessageAndWaitForAck(SBF_CONFIG_RTCM, SBF_CONFIG_TIMEOUT);
+		case(BaseSettingsType::survey_in):
+		default:
+			sendMessageAndWaitForAck(SBF_CONFIG_RTCM_SURVEY_IN, SBF_CONFIG_TIMEOUT);
+			break;
 		}
+	
+		sendMessageAndWaitForAck(SBF_CONFIG_RTCM_STATUS, SBF_CONFIG_TIMEOUT);	
+		_survey_active = true;
+		_survey_activation_date = gps_absolute_time();
 	}
 
 	_configured = true;
@@ -258,7 +270,7 @@ bool GPSDriverSBF::sendMessage(const char *msg)
 
 bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 {
-	SBF_DEBUG("Send MSG: %s", msg);
+	SBF_INFO("Send MSG: %s", msg);
 
 	// Send message
 	int length = static_cast<int>(strlen(msg));
@@ -309,6 +321,7 @@ bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 // 0b0000_0000 = no message handled (not set up yet)
 // 0b0000_0001 = message handled
 // 0b0000_0010 = sat info message handled
+// 0b0000_0100 = base station update (RTCM message or base station position)
 int GPSDriverSBF::receive(unsigned timeout)
 {
 	int handled = 0;
@@ -344,12 +357,13 @@ int GPSDriverSBF::receive(unsigned timeout)
 		}
 
 		if (handled > 0) {
+			SBF_INFO("Handled : %i", handled);
 			return handled;
 		}
 
 		// abort after timeout if no useful packets received
 		if (time_started + timeout * 1000 < gps_absolute_time()) {
-			SBF_DEBUG("timed out, returning");
+			SBF_DEBUG("timed out after %d ms, returning", timeout);
 			return -1;
 		}
 	}
@@ -359,6 +373,7 @@ int GPSDriverSBF::receive(unsigned timeout)
 // 0b0000_0000 = still decoding
 // 0b0000_0001 = message handled
 // 0b0000_0010 = sat info message handled
+// 0b0000_0100 = base station update
 int GPSDriverSBF::parseChar(const uint8_t b)
 {
 	int ret = 0;
@@ -369,7 +384,7 @@ int GPSDriverSBF::parseChar(const uint8_t b)
 			gotRTCMMessage(_rtcm_parsing->message(), _rtcm_parsing->messageLength());
 			decodeInit();
 			_rtcm_parsing->reset();
-			return ret;
+			return 0b0100; // ret
 		}
 	}
 
@@ -481,6 +496,7 @@ int GPSDriverSBF::payloadRxDone()
 	if (_buf.length <= 4 ||
 	    _buf.length > _rx_payload_index ||
 	    _buf.crc16 != crc16(reinterpret_cast<uint8_t *>(&_buf) + 4, _buf.length - 4)) {
+		SBF_TRACE_RXMSG("Rx Unknow");
 		return 0;
 	}
 
@@ -532,7 +548,7 @@ int GPSDriverSBF::payloadRxDone()
 				// other data, but it's really large: >800B)
 				_satellite_info->timestamp = gps_absolute_time();
 				_satellite_info->count = _gps_position->satellites_used;
-				ret = 2;
+				ret |= 2;
 			}
 
 		} else {
@@ -599,6 +615,21 @@ int GPSDriverSBF::payloadRxDone()
 		_rate_count_vel++;
 		_rate_count_lat_lon++;
 		ret |= (_msg_status == 7) ? 1 : 0;
+
+
+		// In RTCM mode, PVTGeodetic is used to get base station survey-in
+		if(_output_mode == OutputMode::RTCM){
+			SurveyInStatus status{};
+			status.latitude = _gps_position->latitude_deg;
+			status.longitude = _gps_position->longitude_deg;
+			status.altitude = _gps_position->altitude_ellipsoid_m;
+			status.duration = _survey_active ? (float)(gps_absolute_time() - _survey_activation_date) / 1000000.0f : 0;
+			status.mean_accuracy = (_buf.payload_pvt_geodetic.h_accuracy + _buf.payload_pvt_geodetic.v_accuracy) / 20; // Value in mm
+			status.flags = (_buf.payload_pvt_geodetic.mode_type > 0 ? 1 : 0) | (_survey_active & 1) << 1; 
+			surveyInStatus(status);
+			ret |= 4; // RTCM infos have been updated
+		}
+
 		//SBF_DEBUG("PVTGeodetic handled");
 		break;
 
@@ -682,6 +713,7 @@ int GPSDriverSBF::payloadRxDone()
 		break;
 
 	default:
+		SBF_TRACE_RXMSG("Rx other.");
 		break;
 	}
 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -270,7 +270,7 @@ bool GPSDriverSBF::sendMessage(const char *msg)
 
 bool GPSDriverSBF::sendMessageAndWaitForAck(const char *msg, const int timeout)
 {
-	SBF_INFO("Send MSG: %s", msg);
+	SBF_DEBUG("Send MSG: %s", msg);
 
 	// Send message
 	int length = static_cast<int>(strlen(msg));
@@ -618,7 +618,7 @@ int GPSDriverSBF::payloadRxDone()
 
 
 		// In RTCM mode, PVTGeodetic is used to get base station survey-in
-		if(_output_mode == OutputMode::RTCM){
+		if (_output_mode == OutputMode::RTCM){
 			SurveyInStatus status{};
 			status.latitude = _gps_position->latitude_deg;
 			status.longitude = _gps_position->longitude_deg;

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -357,7 +357,7 @@ int GPSDriverSBF::receive(unsigned timeout)
 		}
 
 		if (handled > 0) {
-			SBF_INFO("Handled : %i", handled);
+			SBF_DEBUG("Handled : %i", handled);
 			return handled;
 		}
 

--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -57,10 +57,10 @@
 /**** Trace macros, disable for production builds */
 #define SBF_TRACE_PARSER(...)   {/*GPS_INFO(__VA_ARGS__);*/}    /* decoding progress in parse_char() */
 #define SBF_TRACE_RXMSG(...)    {/*GPS_INFO(__VA_ARGS__);*/}    /* Rx msgs in payload_rx_done() */
-#define SBF_INFO(...)           {/*GPS_INFO(__VA_ARGS__);*/}
+#define SBF_INFO(...)           {GPS_INFO(__VA_ARGS__);}
 
 /**** Warning macros, disable to save memory */
-#define SBF_WARN(...)        {/*GPS_WARN(__VA_ARGS__);*/}
+#define SBF_WARN(...)        {GPS_WARN(__VA_ARGS__);}
 #define SBF_DEBUG(...)       {/*GPS_WARN(__VA_ARGS__);*/}
 
 GPSDriverSBF::GPSDriverSBF(GPSCallbackPtr callback, void *callback_user, struct sensor_gps_s *gps_position,

--- a/src/sbf.h
+++ b/src/sbf.h
@@ -63,24 +63,33 @@
 
 #define SBF_CONFIG "setSBFOutput, Stream1, %s, PVTGeodetic+VelCovGeodetic+DOP+AttEuler+AttCovEuler, msec100\n"
 
-#define SBF_CONFIG_DISABLE_OUTPUT "setDataInOut,%s%d,,-RTCMv3\n"
+#define SBF_CONFIG_STATUS "setSBFOutput, Stream1, %s, +ReceiverStatus, msec500\n"
 
-#define SBF_CONFIG_RTCM "" \
-	"setDataInOut, USB1, Auto, RTCMv3\n" \
-	"setPVTMode, Static, All, auto\n"
+#define SBF_CONFIG_DISABLE_OUTPUT "setDataInOut,%s%d,,-RTCMv3-RTCMv2-CMRv2\n"
 
-#define SBF_CONFIG_RTCM_STATIC1 "" \
-	"setReceiverDynamics, Low, Static\n"
+/* RTK Protocol */
+#define SBF_CONFIG_OUTPUT_RTCM3	"setDataInOut, USB1, Auto, RTCMv3+SBF\n"
 
-#define SBF_CONFIG_RTCM_STATIC2 "" \
-	"setPVTMode, Static, , Geodetic1\n"
+#define SBF_CONFIG_OUTPUT_RTCM2	"setDataInOut, USB1, Auto, RTCMv2+SBF\n"
 
-#define SBF_CONFIG_RTCM_STATIC_COORDINATES "" \
-	"setStaticPosGeodetic, Geodetic1, %f, %f, %f\n"
+#define SBF_CONFIG_OUTPUT_CMR	"setDataInOut, USB1, Auto, CMRv2+SBF\n"
+	
+/* RTK Fixed */
+#define SBF_CONFIG_RTCM_STATIC_COORDINATES "setStaticPosGeodetic, Geodetic1, %f, %f, %f\n"
 
-#define SBF_CONFIG_RTCM_STATIC_OFFSET "" \
-	"setAntennaOffset, Main, %f, %f, %f\n"
+#define SBF_CONFIG_RTCM_STATIC_OFFSET "setAntennaOffset, Main, %f, %f, %f\n"
 
+#define SBF_CONFIG_RTCM_STATIC1 "setReceiverDynamics, Low, Static\n"
+
+#define SBF_CONFIG_RTCM_STATIC2 "setPVTMode, Static, , Geodetic1\n"
+
+/* RTK Auto */
+#define SBF_CONFIG_RTCM_SURVEY_IN "setPVTMode, Static, All, auto\n"
+
+/* Status */
+#define SBF_CONFIG_RTCM_STATUS "setSBFOutput, Stream1, USB1, +PVTGeodetic, msec500\n"
+
+/* Reset */
 #define SBF_CONFIG_RESET_HOT "" \
 	SBF_CONFIG_FORCE_INPUT"ExeResetReceiver, soft, none\n"
 
@@ -424,6 +433,8 @@ private:
 
 	const float _heading_offset;
 	const float _pitch_offset;
+	bool _survey_active{false};
+	gps_abstime _survey_activation_date{0};
 };
 
 uint16_t crc16(const uint8_t *buf, uint32_t len);


### PR DESCRIPTION
This PR contains improvement regarding :
- Add base station information using PVTGeodetic messages.
- Re-order sbf message definition in a more cleaver way.
- Return special ret code when receiving message for base station infos to avoid timeout for the receiver.

These changes are part of another PR on QGC to add a base station configuration menu.