### PR TITLE
Configure ubx ITFM on supporting versions

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -606,7 +606,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	// enable jamming monitor
 	// available only on firmware versions earlier than 1.40
-	if (_firmware_version > 0.f && _firmware_version < 1.40f) {
+	if (_firmware_version < 1.40f) {
 		cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
 	}
 
@@ -1904,7 +1904,10 @@ GPSDriverUBX::payloadRxAddMonVer(const uint8_t b)
 
 			if (fwver_str != nullptr) {
 				GPS_INFO("u-blox firmware version: %s", fwver_str + strlen("FWVER="));
-				_firmware_version = atof(strrchr(fwver_str, ' ') + 1);
+				const char *fwver_val = strrchr(fwver_str, ' ')
+				if (fwver_val != nullptr) {
+					_firmware_version = atof(fwver_val + 1);
+				}
 
 				// Check if its a ZED-F9P-15B
 				if ((_board == Board::u_blox9) && strstr(fwver_str, "HPGL1L5")) {

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -605,7 +605,10 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfg_valset_msg_size = initCfgValset();
 
 	// enable jamming monitor
-	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
+	// available only on firmware versions earlier than 1.40
+	if (_firmware_version > 0.f && _firmware_version < 1.40f) {
+		cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
+	}
 
 	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
 		return -1;
@@ -1901,6 +1904,7 @@ GPSDriverUBX::payloadRxAddMonVer(const uint8_t b)
 
 			if (fwver_str != nullptr) {
 				GPS_INFO("u-blox firmware version: %s", fwver_str + strlen("FWVER="));
+				_firmware_version = atof(strrchr(fwver_str, ' ') + 1);
 
 				// Check if its a ZED-F9P-15B
 				if ((_board == Board::u_blox9) && strstr(fwver_str, "HPGL1L5")) {

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1168,6 +1168,7 @@ private:
 	uint16_t _rx_payload_length{0};
 
 	uint32_t _ubx_version{0};
+	float _firmware_version{0.f};
 
 	uint64_t _last_timestamp_time{0};
 


### PR DESCRIPTION
The UBX configuration `CFG-ITFM-ENABLE` has been removed for u-blox FW versions greater than 1.32 (so [1.40](https://content.u-blox.com/sites/default/files/documents/ZED-F9P_FW100HPGL1L5140_RN_UBX-23010071.pdf#%5B%7B%22num%22%3A81%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C59.527%2C704.677%2Cnull%5D), [1.50](https://content.u-blox.com/sites/default/files/documents/ZED-F9P_FW100HPG150_RN_UBXDOC-963802114-12826.pdf#%5B%7B%22num%22%3A81%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C59.527%2C582.677%2Cnull%5D)...). Thus, trying to configure this parameter results in a NAK response, and prevents PX4 from configuring the receiver.

This MR:
- Saves the FW version of the receiver in the variable `_firmware_version`;
- Enables the configuration of `CFG-ITFM-ENABLE` on `_firmware_version < 1.40`.

To convert the FW version from a string to a float, uses `atof` on the last part of the string (after the space delimiting the number in the string), allowing to differentiate values like `HPG 1.51` and `HPGL1L5 1.40` for example.