### PR TITLE
[WIP] ubx: add support for DAN-F10N

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -514,7 +514,7 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_baudrate)
 {
 	// There is no RTCM or USB interface on M10
-	if (_board != Board::u_blox10) {
+	if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
 
 		int cfg_valset_msg_size = initCfgValset();
 
@@ -564,7 +564,8 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	// F9P L1L2 in firmware <1.50 the max update rate with 4 constellations is 9Hz without RTK and 7Hz with RTK
 	// F9P L1L2 in firmware >=1.50 the max update rate with 4 constellations is 7Hz without RTK and 5Hz with RTK
 	// F9P L1L5 the max update rate with 4 constellations is 8Hz without RTK and 7Hz with RTK
-	// Receivers such as M9N can go higher than 10Hz, but the number of used satellites will be restricted to 16. (Not mentioned in datasheet)
+	// DAN-F10N the max update rate is 10Hz with GPS+GAL+BDS(Default)
+	// Receivers such as M9N and DAN-F10N can go higher than 10Hz, but the number of used satellites will be restricted to 16. (Not mentioned in datasheet)
 	int rate_meas = 100; // 10Hz
 
 	switch (_board) {
@@ -738,6 +739,21 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		}
 
 		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true);
+
+	}
+
+	if (_board == Board::u_blox10_L1L5) {
+		// Enable L5 health override, use version 1 of the message
+		cfg_valset_msg_size = initCfgValset(0x01);
+		cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1, cfg_valset_msg_size);
+
+		UBX_DEBUG("Enabling L5 health override");
+
+		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+			return -1;
+		}
+
+		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true);
 	}
 
 	// Configure message rates
@@ -746,7 +762,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
 
 	// There is no RTCM on M10 and M9* (except F9P)
-	if (_board != Board::u_blox10 && _board != Board::u_blox9) {
+	if (_board != Board::u_blox10 && _board != Board::u_blox9 && _board != Board::u_blox10_L1L5) {
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C,
 			      _mode == UBXMode::RoverWithMovingBase || _mode == UBXMode::RoverWithMovingBaseUART1 ? 1 : 0,
@@ -782,7 +798,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 				   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_NMEA, cfg_valset_msg_size);
 
 		// There is no RTCM on M10
-		if (_board != Board::u_blox10) {
+		if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_RTCM3X,
 					   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_RTCM3X, cfg_valset_msg_size);
 		}
@@ -914,10 +930,11 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	return 0;
 }
 
-int GPSDriverUBX::initCfgValset()
+int GPSDriverUBX::initCfgValset(uint8_t version)
 {
 	memset(&_buf.payload_tx_cfg_valset, 0, sizeof(_buf.payload_tx_cfg_valset));
 	_buf.payload_tx_cfg_valset.layers = UBX_CFG_LAYER_RAM;
+	_buf.payload_tx_cfg_valset.version = version;
 	return sizeof(_buf.payload_tx_cfg_valset) - sizeof(_buf.payload_tx_cfg_valset.cfgData);
 }
 
@@ -952,7 +969,7 @@ bool GPSDriverUBX::cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size)
 		}
 
 		// M10 has no USB
-		if (_board != Board::u_blox10) {
+		if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
 			if (!cfgValset<uint8_t>(key_id + 3, value, msg_size)) {
 				return false;
 			}
@@ -1925,6 +1942,12 @@ GPSDriverUBX::payloadRxAddMonVer(const uint8_t b)
 					if (strstr(mod_str, "F9P")) {
 						_board = Board::u_blox9_F9P_L1L2;
 						UBX_DEBUG("F9P detected");
+					}
+
+				} else if (_board == Board::u_blox10) {
+					if (strstr(mod_str, "DAN-F10N")) {
+						_board = Board::u_blox10_L1L5;
+						UBX_DEBUG("DAN-F10N detected");
 					}
 				}
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1012,6 +1012,7 @@ public:
 		u_blox9_F9P_L1L2 = 10, ///< F9P
 		u_blox10 = 11,
 		u_blox9_F9P_L1L5 = 12, ///< ZED-F9P-15B
+		u_blox10_L1L5 = 13, ///< DAN-F10N
 	};
 
 	const Board &board() const { return _board; }
@@ -1092,9 +1093,10 @@ private:
 
 	/**
 	 * Init _buf as CFG-VALSET
+	 * Optionally add the version, otherwise it will default to 0.
 	 * @return size of the message (without any config values)
 	 */
-	int initCfgValset();
+	int initCfgValset(uint8_t version = 0);
 
 	/**
 	 * Start or restart the survey-in procees. This is only used in RTCM ouput mode.


### PR DESCRIPTION
This adds support for the u-blox DAN-F10N GPS. 

https://www.u-blox.com/en/product/dan-f10n-module

The L5 health override changed slightly from the F9P L1L5. The change is not explicity documented, but it is a increment of the UBX-CFG-VALSET version byte from 0 to 1.

F9P L1L5 override - B5 62 06 8A 09 00 00 01 00 00 01 00 32 10 01 DE ED
DAN L1L5 override - B5 62 06 8A 09 00 01 01 00 00 01 00 32 10 01 DF F6

Configuring the constellations currently doesn't work.

[u-blox-F10-SPG-6.00_InterfaceDescription_UBX-23002975.pdf](https://github.com/user-attachments/files/20767030/u-blox-F10-SPG-6.00_InterfaceDescription_UBX-23002975.pdf)
