### PR TITLE
ubx: don't inject RTCM while configuring device

### DIFF
--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1004,7 +1004,7 @@ public:
 	int receive(unsigned timeout) override;
 	int reset(GPSRestartType restart_type) override;
 
-	bool shouldInjectRTCM() override { return _mode != UBXMode::RoverWithMovingBase; }
+	bool shouldInjectRTCM() override { return _configured && _mode != UBXMode::RoverWithMovingBase; }
 
 	enum class Board : uint8_t {
 		unknown = 0,


### PR DESCRIPTION
## Problem
We had a problem with ublox F9P GPSes where, after rebooting the flight controller, the receiver would either:

- Go completely offline
- Get stuck in an initialization loop
- Take a long time to start up

If it went completely offline, we would have to power-cycle the F9P board to get it back online. Interestingly, on a rover/moving base setup, only the moving base was affected.

We were unable to reproduce it on a test-bench setup, only on our drones. After a lot of debugging, we found that this is connected to RTCM injection. While the flight controller restarted, our companion computer still sends RTCM messages. Injecting these messages during receiver configuration appears to sometimes cause undefined behaviour during config. 

I haven't found the exact mechanism of how it fails (each config message is self-contained and RTCM injections should only come between those), but I see no reason to have it enabled during configuration.

## Fix
Don't inject RTCM during configuration

## Tests

I've tested it by running 
```sh
gps stop
gps start -d /dev/ttyS2 -e /dev/ttyS5
```
repeatedly on a drone with CubeOrange FC and two F9Ps configured for RTK heading, autobaud, and a companion computer streaming RTCM.

I haven't tested it thoroughly with all versions of u-blox firmware, but I know we had similar issues also with the most recent firmware versions. These tests are done with `u-blox firmware version: HPG 1.13`

**Tests with updated driver:**
 - 50x attempted restarts without problems

**Control tests with old driver**
- Control test 1: MB rover started first after ~15 sec on 7th restart
- Control test 2: went offline after 1st restart.
- Control test 3: went offline after 6th restart.

**Re-test with updated driver to confirm**
- 20x attempted restarts without problems