### PR TITLE
Expose u-Blox min elevation, min SNR and DGNSS timeout for RTK Fix Improvement

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -75,6 +75,9 @@ GPSDriverUBX::GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void
 	_gps_position(gps_position),
 	_satellite_info(satellite_info),
 	_dyn_model(settings.dynamic_model),
+	_min_cno(settings.min_cno),
+	_min_elev(settings.min_elev),
+	_dgnss_timeout(settings.dgnss_timeout),
 	_mode(settings.mode),
 	_heading_offset(settings.heading_offset),
 	_uart2_baudrate(settings.uart2_baudrate),
@@ -584,6 +587,18 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_UTCSTANDARD, 3 /* USNO (U.S. Naval Observatory derived from GPS) */,
 			   cfg_valset_msg_size);
 	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_DYNMODEL, _dyn_model, cfg_valset_msg_size);
+
+	if (_min_cno != 0) {
+		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_INFIL_MINCNO, _min_cno, cfg_valset_msg_size);
+	}
+
+	if (_min_elev != 0) {
+		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_INFIL_MINELEV, _min_elev, cfg_valset_msg_size);
+	}
+	
+	if (_dgnss_timeout != 0) {
+		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_CONSTR_DGNSSTO, _dgnss_timeout, cfg_valset_msg_size);
+	}
 
 	// disable odometer & filtering
 	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0, cfg_valset_msg_size);

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -328,6 +328,9 @@
 #define UBX_CFG_KEY_NAVSPG_FIXMODE              0x20110011
 #define UBX_CFG_KEY_NAVSPG_UTCSTANDARD          0x2011001c
 #define UBX_CFG_KEY_NAVSPG_DYNMODEL             0x20110021
+#define UBX_CFG_KEY_NAVSPG_INFIL_MINCNO         0x201100a3
+#define UBX_CFG_KEY_NAVSPG_INFIL_MINELEV        0x201100a4
+#define UBX_CFG_KEY_NAVSPG_CONSTR_DGNSSTO       0x201100c4
 
 #define UBX_CFG_KEY_ODO_USE_ODO                 0x10220001
 #define UBX_CFG_KEY_ODO_USE_COG                 0x10220002
@@ -993,6 +996,9 @@ public:
 
 	struct Settings {
 		uint8_t dynamic_model;
+		uint8_t min_cno;
+		int8_t min_elev;
+		uint8_t dgnss_timeout;
 		float heading_offset;
 		int32_t uart2_baudrate;
 		bool ppk_output;
@@ -1172,6 +1178,10 @@ private:
 	uint8_t _rx_ck_a{0};
 	uint8_t _rx_ck_b{0};
 	uint8_t _dyn_model{7};  ///< ublox Dynamic platform model default 7: airborne with <2g acceleration
+	uint8_t _min_cno{0};  ///< ublox minimum satellite signal level for navigation
+	uint8_t _dgnss_timeout{0}; ///< ublox DGNSS timeout.
+
+	int8_t _min_elev{0};  ///< ublox minimum elevation for a GNSS satellite to be used in navigation
 
 	uint16_t _ack_waiting_msg{0};
 	uint16_t _rx_msg{};


### PR DESCRIPTION
This PR increases the minimum elevation for u-Blox GPS from 10 (default) to 15, which is useful for RTK Fix improvement as discussed in the following articles: https://mowerproject.com/2020/07/06/an-even-better-rtk-fix/ and https://discuss.cubepilot.org/t/here-does-not-hold-rtk-fixed-status-reliably-help-please/1056/64. The configuration item address is defined as below.

<img width="1280" height="49" alt="Screenshot from 2025-10-07 11-30-59" src="https://github.com/user-attachments/assets/a0b81307-f7e3-486d-a2c5-908e1df74022" />

Currently, I have only set the hard coded value for the u-Blox GPS for the minimum elevation, but if it is useful we can expose it to PX4 autopilot, and also optionally expose the `CFG-NAVSPG-INFIL_MINCNO` for further improvement as discussed in the article.