### PR TITLE
ubx: add jamming sensitivity

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -81,7 +81,8 @@ GPSDriverUBX::GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void
 	_mode(settings.mode),
 	_heading_offset(settings.heading_offset),
 	_uart2_baudrate(settings.uart2_baudrate),
-	_ppk_output(settings.ppk_output)
+	_ppk_output(settings.ppk_output),
+	_jam_det_sensitivity_hi(settings.jam_det_sensitivity_hi)
 {
 	decodeInit();
 }
@@ -659,6 +660,9 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	// enable jamming monitor
 	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
+
+	// configure jamming detection sensitivity
+	cfgValset<uint8_t>(UBX_CFG_KEY_SEC_JAMDET_SENSITIVITY_HI, _jam_det_sensitivity_hi ? 1 : 0, cfg_valset_msg_size);
 
 	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
 		return -1;

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -339,6 +339,8 @@
 
 #define UBX_CFG_KEY_ITFM_ENABLE                 0x1041000d
 
+#define UBX_CFG_KEY_SEC_JAMDET_SENSITIVITY_HI   0x10f60051
+
 #define UBX_CFG_KEY_RATE_MEAS                   0x30210001
 #define UBX_CFG_KEY_RATE_NAV                    0x30210002
 #define UBX_CFG_KEY_RATE_TIMEREF                0x20210003
@@ -1002,6 +1004,7 @@ public:
 		float heading_offset;
 		int32_t uart2_baudrate;
 		bool ppk_output;
+		bool jam_det_sensitivity_hi;
 		UBXMode mode;
 	};
 
@@ -1202,6 +1205,7 @@ private:
 	const float _heading_offset {};
 	const int32_t _uart2_baudrate {};
 	const bool _ppk_output {};
+	const bool _jam_det_sensitivity_hi {};
 };
 
 


### PR DESCRIPTION
Added option to enable/disable jamming sensitivity on ublox GPS
<img width="1107" height="84" alt="image" src="https://github.com/user-attachments/assets/35f5edc3-84df-429c-b96d-27cd7a83ae13" />
<img width="1067" height="48" alt="image" src="https://github.com/user-attachments/assets/0f1c3b53-3b83-4ec0-8cd3-20e299841f76" />
