### PR TITLE
ubx: add output_rate parameter

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -638,7 +638,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			break;
 
 		case Board::u_blox9_F9P_L1L5:
-			rate_meas = 143; // 7Hz
+			rate_meas = 200; // 5Hz
 			break;
 
 		default:

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -999,6 +999,7 @@ public:
 		uint8_t dgnss_timeout;
 		uint8_t min_cno;
 		int8_t min_elev;
+		uint8_t output_rate;
 		float heading_offset;
 		int32_t uart2_baudrate;
 		bool ppk_output;
@@ -1182,6 +1183,7 @@ private:
 	uint8_t _min_cno{0};  ///< ublox minimum satellite signal level for navigation
 
 	int8_t _min_elev{0};  ///< ublox minimum elevation for a GNSS satellite to be used in navigation
+	uint8_t _output_rate{0};  ///< ublox output rate in Hz, 0 = auto-select based on module
 
 	uint16_t _ack_waiting_msg{0};
 	uint16_t _rx_msg{};


### PR DESCRIPTION
Adds option to allow specifying the module output rate. The new X20 receivers support up to 25Hz measurement rate.