### PR TITLE
ubx: diff corrections age, fix quality, agc, antenna status and power

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2301,6 +2301,54 @@ GPSDriverUBX::payloadRxDone()
 #endif
 		}
 
+		// Parse lastCorrectionAge from flags3 bits 4..1
+		{
+			static constexpr uint16_t correction_age_lut[] = {
+				0xFFFF, 0, 1, 3, 7, 12, 17, 25, 37, 52, 75, 105, 120
+			};
+
+			uint8_t age_bin = (_buf.payload_rx_nav_pvt.flags3 >> 1) & 0xF;
+
+			if (age_bin < sizeof(correction_age_lut) / sizeof(correction_age_lut[0])) {
+				_gps_position->diff_age = correction_age_lut[age_bin];
+
+			} else {
+				_gps_position->diff_age = 120; // >120s
+			}
+		}
+
+		// Derive fix_quality from fix_type
+		switch (_gps_position->fix_type) {
+		case 0: // no fix
+		case 1: // no fix
+			_gps_position->fix_quality = 0;
+			break;
+
+		case 2: // 2D
+			_gps_position->fix_quality = 30;
+			break;
+
+		case 3: // 3D
+			_gps_position->fix_quality = 60;
+			break;
+
+		case 4: // DGPS
+			_gps_position->fix_quality = 75;
+			break;
+
+		case 5: // RTK float
+			_gps_position->fix_quality = 85;
+			break;
+
+		case 6: // RTK fixed
+			_gps_position->fix_quality = 100;
+			break;
+
+		default:
+			_gps_position->fix_quality = 0;
+			break;
+		}
+
 		_gps_position->timestamp = gps_absolute_time();
 		_last_timestamp_time = _gps_position->timestamp;
 
@@ -2621,8 +2669,20 @@ GPSDriverUBX::payloadRxDone()
 		UBX_TRACE_RXMSG("Rx MON-RF");
 
 		_gps_position->noise_per_ms		= _buf.payload_rx_mon_rf.block[0].noisePerMS;
+		_gps_position->automatic_gain_control	= _buf.payload_rx_mon_rf.block[0].agcCnt;
 		_gps_position->jamming_indicator	= _buf.payload_rx_mon_rf.block[0].jamInd;
 		_gps_position->jamming_state		= _buf.payload_rx_mon_rf.block[0].flags;
+		_gps_position->antenna_status		= _buf.payload_rx_mon_rf.block[0].antStatus;
+		_gps_position->antenna_power		= _buf.payload_rx_mon_rf.block[0].antPower;
+
+		// Derive ANTENNA system error from antStatus
+		if (_buf.payload_rx_mon_rf.block[0].antStatus == 3 /* SHORT */
+		    || _buf.payload_rx_mon_rf.block[0].antStatus == 4 /* OPEN */) {
+			_gps_position->system_error |= sensor_gps_s::SYSTEM_ERROR_ANTENNA;
+
+		} else {
+			_gps_position->system_error &= ~sensor_gps_s::SYSTEM_ERROR_ANTENNA;
+		}
 
 		ret = 1;
 		break;

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2317,38 +2317,6 @@ GPSDriverUBX::payloadRxDone()
 			}
 		}
 
-		// Derive fix_quality from fix_type
-		switch (_gps_position->fix_type) {
-		case 0: // no fix
-		case 1: // no fix
-			_gps_position->fix_quality = 0;
-			break;
-
-		case 2: // 2D
-			_gps_position->fix_quality = 30;
-			break;
-
-		case 3: // 3D
-			_gps_position->fix_quality = 60;
-			break;
-
-		case 4: // DGPS
-			_gps_position->fix_quality = 75;
-			break;
-
-		case 5: // RTK float
-			_gps_position->fix_quality = 85;
-			break;
-
-		case 6: // RTK fixed
-			_gps_position->fix_quality = 100;
-			break;
-
-		default:
-			_gps_position->fix_quality = 0;
-			break;
-		}
-
 		_gps_position->timestamp = gps_absolute_time();
 		_last_timestamp_time = _gps_position->timestamp;
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -533,10 +533,11 @@ typedef struct {
 	uint32_t sAcc;          /**< Speed accuracy estimate [mm/s] */
 	uint32_t headAcc;       /**< Heading accuracy estimate (motion and vehicle) [1e-5 deg] */
 	uint16_t pDOP;          /**< Position DOP [0.01] */
-	uint16_t reserved2;
-	uint32_t reserved3;
-	int32_t  headVeh;       /**< (ubx8+ only) Heading of vehicle (2-D) [1e-5 deg] */
-	uint32_t reserved4;     /**< (ubx8+ only) */
+	uint16_t flags3;        /**< Additional flags (bit0: invalidLlh, bits4..1: lastCorrectionAge) */
+	uint32_t reserved0;
+	int32_t  headVeh;       /**< (ubx8+ only) Heading of vehicle (2-D), this is only valid when headVehValid is set, otherwise the output is set to the heading of motion */
+	int16_t  magDec;        /**< (ubx8+ only) Magnetic declination. Only supported in ADR 4.10 and later.*/
+	uint16_t magAcc;        /**< (ubx8+ only) Magnetic declination accuracy. Only supported in ADR 4.10 and later.*/
 } ubx_payload_rx_nav_pvt_t;
 
 /* Rx NAV-TIMEUTC */


### PR DESCRIPTION
## Summary

Surface additional u-blox receiver state via `sensor_gps`:

- **`diff_age`** — differential correction age in seconds, from `UBX-NAV-PVT.flags3.lastCorrectionAge` via a lookup table (binned 0-12 → 0-120 s).
- **`automatic_gain_control`** — from `UBX-MON-RF.agcCnt` (0-8191, % of max gain).
- **`antenna_status`, `antenna_power`** — from `UBX-MON-RF.antStatus` / `antPower`.
- **`SYSTEM_ERROR_ANTENNA`** — set when `antStatus` reports SHORT or OPEN, cleared otherwise.

Also extends `ubx_payload_rx_nav_pvt_t` (adds `flags3`, `magDec`, `magAcc`) to match the ubx8+ spec and make `flags3` addressable.

## Not populated

Abstract quality metrics (`corrections_quality`, `system_status_summary`, `gnss_signal_quality`, `post_processing_quality` on `sensor_gnss_status`) are left at 255 — u-blox has no 0-10 metric equivalent to Septentrio's `QualityInd`. Synthesizing from `fix_type` would be circular.

## Related

- PX4-Autopilot integration: PX4/PX4-Autopilot#26438
- DSDL `Quality` message: dronecan/DSDL#77
