### PR TITLE
fix(ubx): increase RTCM 1005 output rate for moving base

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2697,7 +2697,7 @@ GPSDriverUBX::activateRTCMOutput(bool reduce_update_rate)
 			cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, 1000, cfg_valset_msg_size);
 		}
 
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 5, cfg_valset_msg_size);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 1, cfg_valset_msg_size);


### PR DESCRIPTION
Change RTCM 3.x Type 1005 (base station ARP) output rate from every 5th measurement to every measurement. With tighter DGNSS timeouts, the previous 5s interval can cause intermittent RTK fix loss on the rover because the base station position message arrived too infrequently.

Supersedes #109