### PR TITLE
fix(nmea): prevent double-counting velocity rate from VTG

### DIFF
--- a/src/nmea.cpp
+++ b/src/nmea.cpp
@@ -897,8 +897,11 @@ int GPSDriverNMEA::handleMessage(int len)
 			_gps_position->vel_ned_valid = true; /** Flag to indicate if NED speed is valid */
 			_gps_position->c_variance_rad = 0.1f;
 			_gps_position->s_variance_m_s = 0;
-			_VEL_received = true;
-			_rate_count_vel++;
+
+			if (!_VEL_received) {
+				_VEL_received = true;
+				_rate_count_vel++;
+			}
 
 			_gps_position->cog_rad = track_rad;
 		}


### PR DESCRIPTION
## Summary
- VTG unconditionally incremented `_rate_count_vel` whenever the unicore agrica parser was inactive, even though RMC had already incremented it in the same epoch. This caused the velocity publish rate to appear roughly 2× the position rate when a module emitted both RMC and VTG per fix (typical NMEA setup).
- Guard the VTG increment with `!_VEL_received` so it only counts when RMC hasn't already — mirrors the dedup already present in the RMC handler.

Fixes #185.