### PR TITLE
feat: add GPSHelper::isMovingBase() virtual

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -248,6 +248,12 @@ public:
 	 */
 	virtual bool shouldInjectRTCM() { return true; }
 
+	/**
+	 * True if this GPS is configured as a moving base (its RTCM output is
+	 * moving-baseline data intended for a rover, not external corrections).
+	 */
+	virtual bool isMovingBase() const { return false; }
+
 protected:
 
 	/**

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1021,6 +1021,11 @@ public:
 
 	bool shouldInjectRTCM() override { return _configured && _mode != UBXMode::RoverWithMovingBase; }
 
+	bool isMovingBase() const override
+	{
+		return _mode == UBXMode::MovingBase || _mode == UBXMode::MovingBaseUART1;
+	}
+
 	enum class Board : uint8_t {
 		unknown = 0,
 		u_blox5 = 5,


### PR DESCRIPTION
## Summary

Adds a `virtual bool isMovingBase() const` on `GPSHelper` (defaults to `false`) and overrides it in `GPSDriverUBX` to return true when the UBX mode is `MovingBase` or `MovingBaseUART1`.

Companion PR in PX4-Autopilot (PX4/PX4-Autopilot#TBD) uses this to route moving-baseline RTCM (RTCM 4072) to a dedicated `rtcm_moving_baseline` uORB topic, separate from external fixed-base corrections on `rtcm_corrections`. That fixes the topic conflation described in PX4/PX4-Autopilot#27088, which breaks dual GPS (moving base + rover) + fixed base setups.