### PR TITLE
fix(ubx): use dedicated TX buffer for CFG-VALSET

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -170,7 +170,7 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 
 			bool cfg_valset_success = false;
 
-			if (sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 
 				// Note: The M10 comes up sending NMEA sentences at 9600. It can't
 				// respond with an ACK until the current sentence has completed transmission.
@@ -188,7 +188,7 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 				cfg_valset_msg_size = initCfgValset();
 				cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART1_BAUDRATE, desired_baudrate, cfg_valset_msg_size);
 
-				if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+				if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 					continue;
 				}
 
@@ -286,7 +286,7 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 
 		bool cfg_valset_success = false;
 
-		if (sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 
 			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) == 0) {
 				cfg_valset_success = true;
@@ -574,7 +574,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_NMEA, 0, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -651,7 +651,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_NAV, 1, cfg_valset_msg_size);
 	cfgValset<uint8_t>(UBX_CFG_KEY_RATE_TIMEREF, 0, cfg_valset_msg_size);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 		return -1;
 	}
 
@@ -663,7 +663,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_NAVHPG_DGNSSMODE, 3 /* RTK Fixed */, cfg_valset_msg_size);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 		return -1;
 	}
 
@@ -674,7 +674,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	// enable jamming monitor
 	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 		return -1;
 	}
 
@@ -686,7 +686,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfg_valset_msg_size = initCfgValset();
 	cfgValset<uint8_t>(UBX_CFG_KEY_SEC_JAMDET_SENSITIVITY_HI, _jam_det_sensitivity_hi ? 1 : 0, cfg_valset_msg_size);
 
-	if (sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
 			UBX_WARN("CFG-SEC-JAMDET_SENSITIVITY_HI not supported by this receiver");
 		}
@@ -871,7 +871,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			}
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			UBX_DEBUG("UBX GNSS config send failed");
 			return -1;
 		}
@@ -892,7 +892,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_ENA, 0, cfg_valset_msg_size);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -905,7 +905,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 		UBX_DEBUG("Enabling L5 health override");
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -935,7 +935,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1, cfg_valset_msg_size);
 	}
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 		return -1;
 	}
 
@@ -969,7 +969,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 					   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_RTCM3X, cfg_valset_msg_size);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -993,7 +993,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 1, cfg_valset_msg_size); // Galileo MSM7
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 1, cfg_valset_msg_size); // BeiDou MSM7
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1017,7 +1017,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1071,7 +1071,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1, cfg_valset_msg_size);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1089,7 +1089,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1139,7 +1139,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1, 1, cfg_valset_msg_size);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1161,7 +1161,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1175,24 +1175,27 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 int GPSDriverUBX::initCfgValset()
 {
-	memset(&_buf.payload_tx_cfg_valset, 0, sizeof(_buf.payload_tx_cfg_valset));
-	_buf.payload_tx_cfg_valset.layers = UBX_CFG_LAYER_RAM;
-	return sizeof(_buf.payload_tx_cfg_valset) - sizeof(_buf.payload_tx_cfg_valset.cfgData);
+	static_assert(sizeof(_tx_cfg_valset_buf) >= sizeof(ubx_payload_tx_cfg_valset_t),
+		      "_tx_cfg_valset_buf must hold at least the CFG-VALSET header");
+	auto *header = reinterpret_cast<ubx_payload_tx_cfg_valset_t *>(_tx_cfg_valset_buf);
+	memset(_tx_cfg_valset_buf, 0, sizeof(_tx_cfg_valset_buf));
+	header->layers = UBX_CFG_LAYER_RAM;
+	return sizeof(*header) - sizeof(header->cfgData);
 }
 
 template<typename T>
 bool GPSDriverUBX::cfgValset(uint32_t key_id, T value, int &msg_size)
 {
-	if (msg_size + sizeof(key_id) + sizeof(value) > sizeof(_buf)) {
-		// If this happens use several CFG-VALSET messages instead of one
+	if (msg_size + sizeof(key_id) + sizeof(value) > sizeof(_tx_cfg_valset_buf)) {
+		// If this ever fires, either bump UBX_CFG_VALSET_BUF_SIZE or split the
+		// batch into multiple CFG-VALSET messages at the call site.
 		UBX_WARN("buf for CFG_VALSET too small");
 		return false;
 	}
 
-	uint8_t *buffer = (uint8_t *)&_buf.payload_tx_cfg_valset;
-	memcpy(buffer + msg_size, &key_id, sizeof(key_id));
+	memcpy(_tx_cfg_valset_buf + msg_size, &key_id, sizeof(key_id));
 	msg_size += sizeof(key_id);
-	memcpy(buffer + msg_size, &value, sizeof(value));
+	memcpy(_tx_cfg_valset_buf + msg_size, &value, sizeof(value));
 	msg_size += sizeof(value);
 	return true;
 }
@@ -1322,7 +1325,7 @@ int GPSDriverUBX::restartSurveyIn()
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 0, cfg_valset_msg_size);
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, 0, cfg_valset_msg_size);
 	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 0, cfg_valset_msg_size);
-	sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+	sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size);
 	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 
 	if (_base_settings.type == BaseSettingsType::survey_in) {
@@ -1334,7 +1337,7 @@ int GPSDriverUBX::restartSurveyIn()
 		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT, _base_settings.settings.survey_in.acc_limit, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 5, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1361,7 +1364,7 @@ int GPSDriverUBX::restartSurveyIn()
 		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_FIXED_POS_ACC, (uint32_t)(settings.position_accuracy * 10.f),
 				    cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 
@@ -1868,10 +1871,9 @@ GPSDriverUBX::payloadRxInit()
 					_disable_cmd_last = t;
 					UBX_DEBUG("ubx disabling msg 0x%04x (0x%04x)", SWAP16((unsigned)_rx_msg), (uint16_t)key_id);
 
-					// this will overwrite _buf, which is fine, as we'll return -1 and abort further parsing
 					int cfg_valset_msg_size = initCfgValset();
 					cfgValsetPort(key_id, 0, cfg_valset_msg_size);
-					sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size);
+					sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size);
 				}
 			}
 
@@ -2717,7 +2719,7 @@ GPSDriverUBX::activateRTCMOutput(bool reduce_update_rate)
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 0, cfg_valset_msg_size);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, cfg_valset_msg_size)) {
+		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 			return -1;
 		}
 

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -55,6 +55,11 @@
 #define UBX_CONFIG_TIMEOUT    250 // ms, timeout for waiting ACK
 #define UBX_PACKET_TIMEOUT    8   // ms, if now data during this delay assume that full update received
 
+// Dedicated TX buffer for CFG-VALSET. Sized independently of ubx_buf_t (the RX
+// union) so adding config keys can't push the batch past sizeof(ubx_buf_t),
+// which is bounded by the largest RX payload (NAV-PVT, 92 B).
+#define UBX_CFG_VALSET_BUF_SIZE 256
+
 #define DISABLE_MSG_INTERVAL  1000000    // us, try to disable message with this interval
 
 #define FNV1_32_INIT          static_cast<uint32_t>(0x811c9dc5)    // init value for FNV1 hash algorithm
@@ -946,7 +951,6 @@ typedef union {
 	ubx_payload_tx_cfg_msg_t          payload_tx_cfg_msg;
 	ubx_payload_tx_cfg_tmode3_t       payload_tx_cfg_tmode3;
 	ubx_payload_tx_cfg_cfg_t          payload_tx_cfg_cfg;
-	ubx_payload_tx_cfg_valset_t       payload_tx_cfg_valset;
 	ubx_payload_tx_cfg_gnss_t         payload_tx_cfg_gnss;
 	ubx_payload_rx_nav_relposned_t    payload_rx_nav_relposned;
 } ubx_buf_t;
@@ -1079,7 +1083,7 @@ private:
 	int configureDevicePreV27(const GNSSSystemsMask &gnssSystems);
 
 	/**
-	 * Add a configuration value to _buf and increase the message size msg_size as needed
+	 * Add a configuration value to _tx_cfg_valset_buf and increase the message size msg_size as needed
 	 * @param key_id one of the UBX_CFG_KEY_* constants
 	 * @param value configuration value
 	 * @param msg_size CFG-VALSET message size: this is an input & output param
@@ -1112,7 +1116,7 @@ private:
 	uint32_t fnv1_32_str(uint8_t *str, uint32_t hval);
 
 	/**
-	 * Init _buf as CFG-VALSET
+	 * Init _tx_cfg_valset_buf as CFG-VALSET
 	 * @return size of the message (without any config values)
 	 */
 	int initCfgValset();
@@ -1170,6 +1174,7 @@ private:
 	satellite_info_s       *_satellite_info {nullptr};
 	ubx_ack_state_t         _ack_state{UBX_ACK_IDLE};
 	ubx_buf_t               _buf{};
+	uint8_t                 _tx_cfg_valset_buf[UBX_CFG_VALSET_BUF_SIZE]{};
 	ubx_decode_state_t      _decode_state{};
 	ubx_rxmsg_state_t       _rx_state{UBX_RXMSG_IGNORE};
 


### PR DESCRIPTION
## Summary

`cfgValset()` was building CFG-VALSET payloads inside `_buf`, the union of
all RX/TX payload structs. That meant the max batch size was bounded by
`sizeof(ubx_buf_t) = sizeof(ubx_payload_rx_nav_pvt_t) = 92 B`.

In `UBXMode::MovingBase` the F9P L1/L2 batch is 102 B:

- 8 UART2 protocol/line keys (u8) + `UART2_BAUDRATE` (u32)
- `MSGOUT_RTCM_3X_TYPE1230_UART2`
- 4 MSM4 enables (`TYPE1074/1084/1094/1124`)
- 4 MSM7 disables (`TYPE1077/1087/1097/1127`)
- `MSGOUT_RTCM_3X_TYPE4072_0_UART2`

The last two keys — `TYPE1127_UART2 = 0` and `TYPE4072_0_UART2 = 1` —
silently fail the `msg_size + sizeof(key) + sizeof(value) > sizeof(_buf)`
check and are dropped with `WARN [gps] buf for CFG_VALSET too small`.

Dropping `TYPE4072_0_UART2` is the symptom: the moving-base F9P stops
emitting RTCM 4072, and the rover in `RoverWithMovingBase` can't complete
moving-baseline RTK — it stalls at fix 3/4 instead of reaching fix 6. The
same overflow hits `UBXMode::MovingBaseUART1` (F9P L1/L2, 19 keys / 102 B).

Regression introduced in `f1c59b3` when the MSM7 disable keys were added
to the non-PPK branch alongside the existing MSM4 enables.

## Fix

Move the CFG-VALSET build buffer out of the RX union into a dedicated
256-B TX buffer (`_tx_cfg_valset_buf`), so adding config keys can't
silently overrun and the RX buffer's size stops being an implicit cap on
TX batches.

- New `UBX_CFG_VALSET_BUF_SIZE = 256` and `_tx_cfg_valset_buf` member.
- `initCfgValset()` / `cfgValset()` target the new buffer; `static_assert`
  that it's at least the CFG-VALSET header size.
- 24 `sendMessage(UBX_MSG_CFG_VALSET, (uint8_t *)&_buf, ...)` call sites
  updated to pass `_tx_cfg_valset_buf`.
- Drops the now-unused `payload_tx_cfg_valset` member from `ubx_buf_t`.

Current worst-case batch (102 B) now has ~150 B headroom; the overflow
warn only fires if someone adds enough keys in one batch to exceed 256 B.

## Alternatives considered

- **#208** splits the message on overflow by calling `sendMessage` +
  `waitForAck` inside `cfgValset`. Fixes the immediate symptom, but
  changes `cfgValset` from a pure append to a function with I/O side
  effects; most callers ignore its return value, so an intermediate ACK
  timeout/NAK silently drops the triggering key with no visible warn.
  Also leaves the 92 B implicit cap in place for future key additions.
- **Call-site split** of the `MovingBase` / `MovingBaseUART1` branches
  into two `init / ... / sendMessage / waitForAck` groups. Targeted but
  doesn't prevent the next branch from silently tripping the same cap.

## Test

- Built `make px4_sitl_default` (1161/1161) and `make ark_fmu-v6x_default`
  (1214/1214, 99.60% flash — the +256 B lives in AXI_SRAM).
- `make format` clean.

Supersedes #208
Fixes PX4/PX4-Autopilot#27177
Fixes PX4/PX4-GPSDrivers#207