### PR TITLE
style: fix trailing whitespace and array-brace spacing

### DIFF
--- a/src/sbf.cpp
+++ b/src/sbf.cpp
@@ -509,7 +509,7 @@ int GPSDriverSBF::payloadRxDone()
 			_gps_position->fix_type = 1;
 
 		} else {
-		
+
 			switch (_buf.payload_pvt_geodetic.mode_type) {
 			case 6:
 				_gps_position->fix_type = 4;

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1174,7 +1174,7 @@ private:
 	satellite_info_s       *_satellite_info {nullptr};
 	ubx_ack_state_t         _ack_state{UBX_ACK_IDLE};
 	ubx_buf_t               _buf{};
-	uint8_t                 _tx_cfg_valset_buf[UBX_CFG_VALSET_BUF_SIZE]{};
+	uint8_t                 _tx_cfg_valset_buf[UBX_CFG_VALSET_BUF_SIZE] {};
 	ubx_decode_state_t      _decode_state{};
 	ubx_rxmsg_state_t       _rx_state{UBX_RXMSG_IGNORE};
 


### PR DESCRIPTION
## Summary

Two tiny formatting fixes so the files pass PX4-Autopilot's \`make check_format\` (astyle 3.x).

## Problem

When this submodule is vendored into PX4-Autopilot, \`make check_format\` flags:

- \`src/sbf.cpp\` — trailing whitespace on an otherwise-empty line inside \`payloadRxDone()\`
- \`src/ubx.h\` — missing space between the array bound and the brace-init for \`_tx_cfg_valset_buf\`

## Solution

Apply the astyle-suggested fixes. No behavior change.