### PR TITLE
feat(ubx): separate RTCM corrections from moving-baseline injection

### DIFF
--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -244,11 +244,11 @@ public:
 	void storeUpdateRates();
 
 	/**
-	 * Whether external (fixed-base / GCS) RTCM corrections should be injected into this
-	 * receiver. True for any configured receiver - rover, moving base, or plain GPS - since
-	 * all of them can use fixed-base corrections.
+	 * Whether the receiver is configured and ready to accept injected data. Gates all
+	 * injection (RTCM corrections and moving-baseline) so nothing is written to the device
+	 * mid-configuration. Defaults to true; drivers with a configuration handshake override it.
 	 */
-	virtual bool shouldInjectRTCMCorrections() const { return true; }
+	virtual bool receiverReady() const { return true; }
 
 	/**
 	 * Whether moving-baseline RTCM (e.g. RTCM 4072 from a peer moving-base GPS) should be

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -244,9 +244,20 @@ public:
 	void storeUpdateRates();
 
 	/**
-	 * Allow a driver to disable RTCM injection
+	 * Whether external (fixed-base / GCS) RTCM corrections should be injected into this
+	 * receiver. True for any configured receiver - rover, moving base, or plain GPS - since
+	 * all of them can use fixed-base corrections.
 	 */
-	virtual bool shouldInjectRTCM() { return true; }
+	virtual bool shouldInjectRTCMCorrections() const { return true; }
+
+	/**
+	 * Whether moving-baseline RTCM (e.g. RTCM 4072 from a peer moving-base GPS) should be
+	 * injected into this receiver over its main link. True only for a heading rover that
+	 * receives the baseline through the flight controller (UART1 / CAN). A rover wired
+	 * directly to the moving base (UART2) gets it in hardware, and a moving base produces
+	 * rather than consumes it - both return false.
+	 */
+	virtual bool shouldInjectMovingBaseline() const { return false; }
 
 	/**
 	 * True if this GPS is configured as a moving base (its RTCM output is

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -921,7 +921,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	if (_board != Board::u_blox10 && _board != Board::u_blox9 && _board != Board::u_blox10_L1L5) {
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1, cfg_valset_msg_size);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C,
-			      _mode == UBXMode::RoverWithMovingBase || _mode == UBXMode::RoverWithMovingBaseUART1 ? 1 : 0,
+			      _mode == UBXMode::RoverWithMovingBaseUART2 || _mode == UBXMode::RoverWithMovingBaseUART1 ? 1 : 0,
 			      cfg_valset_msg_size);
 	}
 
@@ -1001,7 +1001,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			return -1;
 		}
 
-	} else if (_mode == UBXMode::RoverWithStaticBaseUart2 || _mode == UBXMode::RoverWithMovingBase) {
+	} else if (_mode == UBXMode::RoverWithStaticBaseUART2 || _mode == UBXMode::RoverWithMovingBaseUART2) {
 		UBX_DEBUG("Configuring UART2 for rover");
 		cfg_valset_msg_size = initCfgValset();
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
@@ -1025,7 +1025,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			return -1;
 		}
 
-	} else if (_mode == UBXMode::MovingBase) {
+	} else if (_mode == UBXMode::MovingBaseUART2) {
 		UBX_DEBUG("Configuring UART2 for moving base");
 		// enable RTCM output on uart2 + set baudrate
 		cfg_valset_msg_size = initCfgValset();

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1023,7 +1023,7 @@ public:
 	int receive(unsigned timeout) override;
 	int reset(GPSRestartType restart_type) override;
 
-	bool shouldInjectRTCMCorrections() const override { return _configured; }
+	bool receiverReady() const override { return _configured; }
 
 	bool shouldInjectMovingBaseline() const override
 	{

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -992,12 +992,12 @@ class GPSDriverUBX : public GPSBaseStationSupport
 public:
 	enum class UBXMode : uint8_t {
 		Normal,                    ///< all non-heading configurations
-		RoverWithMovingBase,       ///< expect RTCM input on UART2 from a moving base for heading output
-		MovingBase,                ///< RTCM output on UART2 to a rover (GPS is installed on the vehicle)
-		RoverWithMovingBaseUART1, ///< expect RTCM input on UART1 from a moving base for heading output
-		MovingBaseUART1,          ///< RTCM output on UART1 to a rover (GPS is installed on the vehicle)
-		RoverWithStaticBaseUart2,  ///< expect RTCM input on UART2 from a static base.
-		GroundControlStation, ///< NMEA output on UART2 to a ground control station (GPS is installed in GCS)
+		RoverWithMovingBaseUART2,  ///< heading rover; receives moving-base RTCM on UART2 (wired directly to the moving base)
+		MovingBaseUART2,           ///< moving base; outputs RTCM on UART2 (wired directly to the rover)
+		RoverWithMovingBaseUART1,  ///< heading rover; receives moving-base RTCM on UART1 (relayed via the flight controller)
+		MovingBaseUART1,           ///< moving base; outputs RTCM on UART1 (relayed to the rover via the flight controller)
+		RoverWithStaticBaseUART2,  ///< heading rover; receives static-base RTCM on UART2
+		GroundControlStation,      ///< NMEA output to a ground control station (GPS is installed in the GCS)
 	};
 
 	struct Settings {
@@ -1023,11 +1023,18 @@ public:
 	int receive(unsigned timeout) override;
 	int reset(GPSRestartType restart_type) override;
 
-	bool shouldInjectRTCM() override { return _configured && _mode != UBXMode::RoverWithMovingBase; }
+	bool shouldInjectRTCMCorrections() const override { return _configured; }
+
+	bool shouldInjectMovingBaseline() const override
+	{
+		// Only the UART1 heading rover receives the moving baseline over its main link; the UART2
+		// rover gets it directly in hardware and a moving base produces rather than consumes it.
+		return _configured && _mode == UBXMode::RoverWithMovingBaseUART1;
+	}
 
 	bool isMovingBase() const override
 	{
-		return _mode == UBXMode::MovingBase || _mode == UBXMode::MovingBaseUART1;
+		return _mode == UBXMode::MovingBaseUART2 || _mode == UBXMode::MovingBaseUART1;
 	}
 
 	enum class Board : uint8_t {


### PR DESCRIPTION
## Summary

Split the single RTCM injection gate into two role-specific `GPSHelper` virtuals, and make every `UBXMode` name its UART explicitly. Consumed by https://github.com/PX4/PX4-Autopilot/pull/27097

## Problem

`shouldInjectRTCM()` conflated "is the receiver configured/ready" with "should it receive the moving baseline". It returned false for the UART2 heading rover, wrongly blocking that rover from fixed-base corrections over its main link, and left no way to gate the two RTCM streams per role. The `UBXMode` names compounded it: `RoverWithMovingBase` and `MovingBase` silently meant UART2 alongside explicit `*UART1` siblings, and `RoverWithStaticBaseUart2` used inconsistent casing.

## Solution

Replace `shouldInjectRTCM()` with two virtuals. `receiverReady()` (UBX: `_configured`) gates all injection so nothing is written mid-configuration, and lets every configured receiver accept fixed-base corrections — including the UART2 rover. `shouldInjectMovingBaseline()` (UBX: only `RoverWithMovingBaseUART1`) injects the moving baseline over the main link; a UART2 rover gets it in hardware and a moving base produces it, so both return false. Rename `RoverWithMovingBase` → `RoverWithMovingBaseUART2`, `MovingBase` → `MovingBaseUART2`, and `RoverWithStaticBaseUart2` → `RoverWithStaticBaseUART2`.
