### PR TITLE
fix(ubx): tolerate CFG-ODO-* removal on ZED-X20P (HPG 2.10+)

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -602,12 +602,6 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_CONSTR_DGNSSTO, _dgnss_timeout, cfg_valset_msg_size);
 	}
 
-	// disable odometer & filtering
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_COG, 0, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPVEL, 0, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPCOG, 0, cfg_valset_msg_size);
-
 	// measurement rate
 	// M9N max rate is 8Hz for all satellites, above 8Hz the number of used satellites is restricted to 16.
 	// F9P L1L2 in firmware <1.50 the max update rate with 4 constellations is 9Hz without RTK and 7Hz with RTK
@@ -657,6 +651,18 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
 		return -1;
+	}
+
+	// Disable odometer. Separate, non-fatal VALSET: CFG-ODO-* was removed on the
+	// F20 platform (ZED-X20P HPG 2.10+), so a NAK here must not abort config.
+	cfg_valset_msg_size = initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0, cfg_valset_msg_size);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_COG, 0, cfg_valset_msg_size);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPVEL, 0, cfg_valset_msg_size);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPCOG, 0, cfg_valset_msg_size);
+
+	if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 	}
 
 	// RTK (optional, as only RTK devices like F9P support it)


### PR DESCRIPTION
## Summary

Fixes ZED-X20P configuration looping on HPG 2.10 firmware by moving the `CFG-ODO-*` keys out of the fatally-acked configuration VALSET.

## Problem

HPG 2.10 for the u-blox F20 platform (ZED-X20P) removes the `CFG-ODO-*` configuration group ("odometer feature deprecated"). The driver disables the odometer by setting those four keys inside the main NAVSPG/RATE `CFG-VALSET`, which is checked with a fatal ack. The receiver NAKs the entire VALSET because the keys no longer exist, so `configureDevice()` returns `-1` and the driver restarts configuration indefinitely — the module never reaches the receive loop and never outputs a position.

## Solution

Send the `CFG-ODO-*` keys in a dedicated `CFG-VALSET` with a non-fatal ack, matching the existing handling for SBAS and the jamming-detection keys. A NAK on firmware that dropped the group is now ignored and configuration proceeds. Behavior is unchanged on F9/M9/M10 firmware where the keys still exist.
