### PR TITLE
ubx: log automatic_gain_control correctly

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2760,6 +2760,7 @@ GPSDriverUBX::payloadRxDone()
 		UBX_TRACE_RXMSG("Rx MON-RF");
 
 		_gps_position->noise_per_ms		= _buf.payload_rx_mon_rf.block[0].noisePerMS;
+		_gps_position->automatic_gain_control	= _buf.payload_rx_mon_rf.block[0].agcCnt;
 		_gps_position->jamming_indicator	= _buf.payload_rx_mon_rf.block[0].jamInd;
 		_gps_position->jamming_state		= _buf.payload_rx_mon_rf.block[0].flags;
 


### PR DESCRIPTION
`automatic_gain_control` was already filled from `agcCnt` in the `MON-HW` paths:

https://github.com/PX4/PX4-GPSDrivers/commit/8ba8d9f19c2328955424d035d6ce5a08ef11a371

But here it is also available [1], so let's populate the topic.

1: https://content.u-blox.com/sites/default/files/documents/u-blox-F9-HPG-1.32_InterfaceDescription_UBX-22008968.pdf, Section 3.14.9, p133