### PR TITLE
fix(ubx): disable unused NAV-TIMEGPS and RXM-RAWX/SFRBX msgout

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -955,6 +955,15 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1, cfg_valset_msg_size);
 	}
 
+	// Explicitly disable the messages this driver never consumes. We do not enable them,
+	// but they can be left on in the receiver's non-volatile config by other software
+	// (u-center, or another firmware such as ArduPilot, which writes CFG-VALSET to the
+	// BBR/FLASH layers). Clearing them here rather than waiting for payloadRxInit() to
+	// notice them avoids wasting UART bandwidth on every boot.
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C, 0, cfg_valset_msg_size);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C, 0, cfg_valset_msg_size);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C, 0, cfg_valset_msg_size);
+
 	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
 		return -1;
 	}


### PR DESCRIPTION
## Summary

Explicitly clear the `CFG-MSGOUT` rates for NAV-TIMEGPS, RXM-RAWX and RXM-SFRBX in the message-rate `CFG-VALSET` batch.

## Problem

The driver never consumes these three messages — they have no `case` in the `payloadRxInit()` message switch, so they fall through to `UBX_RXMSG_DISABLE`. That path clears them reactively, but only one message per `DISABLE_MSG_INTERVAL` (1 s) and only after `_configured` is set, so they stream during and after bring-up.

They can be left enabled in the receiver's non-volatile config by other software: u-center, or another firmware — ArduPilot's CFGv2 driver writes `CFG-VALSET` to RAM+BBR+FLASH and enables NAV-TIMEGPS at 5 Hz plus RXM-RAWX when raw logging is on. Since this driver only ever writes the RAM layer, those settings survive every power cycle and the reactive disable has to re-fight them on each boot. On a CAN node at 115200 that is bandwidth we can't spare.

## Solution

Set the three rates to 0 in the batch that already configures message output, so they are off before any of them can stream. No new messages are enabled and nothing that is consumed changes; PPK output is unaffected as it uses RTCM MSM7, not RXM raw.
