### PR TITLE
fix(ubx): clear _configured on reset so injection stops until reconfigured

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2931,10 +2931,6 @@ GPSDriverUBX::reset(GPSRestartType restart_type)
 	}
 
 	if (sendMessage(UBX_MSG_CFG_RST, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_rst))) {
-		// The receiver reboots onto its saved configuration, so ours is gone.
-		// receiverReady() gates correction injection, and writes landing in a
-		// rebooting receiver are lost - assistance data especially, since the
-		// caster only sends it once per connection.
 		_configured = false;
 		return 0;
 	}

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2931,6 +2931,11 @@ GPSDriverUBX::reset(GPSRestartType restart_type)
 	}
 
 	if (sendMessage(UBX_MSG_CFG_RST, (uint8_t *)&_buf, sizeof(_buf.payload_tx_cfg_rst))) {
+		// The receiver reboots onto its saved configuration, so ours is gone.
+		// receiverReady() gates correction injection, and writes landing in a
+		// rebooting receiver are lost - assistance data especially, since the
+		// caster only sends it once per connection.
+		_configured = false;
 		return 0;
 	}
 


### PR DESCRIPTION
## Summary

`GPSDriverUBX::reset()` sends UBX-CFG-RST but leaves `_configured` set, so the driver keeps reporting a receiver that is rebooting as ready.

## Problem

`receiverReady()` returns `_configured`, and PX4's GPS driver gates correction injection on it — `GPS::handleInjectDataTopic()` returns early when it is false, so nothing is written to a receiver mid-configuration. `configure()` maintains the flag correctly (false on entry, true on the final success path), but `reset()` never touches it.

After a commanded reset the receiver reboots onto its saved configuration, which is not the one we just applied, and it is not parsing our correction stream while it does. `_configured` stays true across all of it, so the flight controller keeps writing corrections into the reboot until `receive()` finally times out and the driver re-runs `configure()`. Every byte written in that window is lost.

AssistNow (MGA) is the case that made this visible: a PointPerfect `*-MGA` mountpoint delivers the assistance burst once per NTRIP connection, so a burst that lands during the reboot is gone until the client drops the session and connects again for another one.

## Solution

Clear `_configured` when the CFG-RST is sent. Injection stops immediately, and since NAV messages are already ignored while unconfigured, `receive()` returns -1 on its next timeout and the driver re-runs `configure()` promptly rather than waiting for the rebooting receiver to fall silent on its own — which it has to do anyway, the reset having dropped the configuration we applied.

Built for `ark_fmu-v6x_default`.