### PR TITLE
fix(ubx): report time_utc_usec as 0 while the receiver's time is invalid

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -81,6 +81,7 @@ GPSDriverUBX::GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void
 	_output_rate(settings.output_rate),
 	_mode(settings.mode),
 	_heading_offset(settings.heading_offset),
+	_uart1_baudrate(settings.uart1_baudrate),
 	_uart2_baudrate(settings.uart2_baudrate),
 	_ppk_output(settings.ppk_output),
 	_jam_det_sensitivity_hi(settings.jam_det_sensitivity_hi)
@@ -121,6 +122,13 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 
 		if ((_mode == UBXMode::RoverWithMovingBaseUART1) || (_mode == UBXMode::MovingBaseUART1)) {
 			desired_baudrate = UART1_BAUDRATE_HEADING;
+		}
+
+		// An explicit UART1 target wins. The probe scan is unaffected, so this
+		// cannot lock the driver out of a receiver at its power-on default the
+		// way a fixed baudrate does.
+		if (_uart1_baudrate > 0) {
+			desired_baudrate = _uart1_baudrate;
 		}
 
 		for (baud_i = 0; baud_i < sizeof(baudrates) / sizeof(baudrates[0]); baud_i++) {
@@ -223,7 +231,7 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 					continue;
 				}
 
-				if (auto_baudrate) {
+				if (auto_baudrate && _uart1_baudrate == 0) {
 					desired_baudrate = UBX_TX_CFG_PRT_BAUDRATE;
 				}
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2398,6 +2398,12 @@ GPSDriverUBX::payloadRxDone()
 #else
 			_gps_position->time_utc_usec = 0;
 #endif
+
+		} else {
+			// The struct is reused across messages, so without this a receiver
+			// that lost time in a reset keeps reporting the last time it knew.
+			// 0 is the defined "unavailable" value.
+			_gps_position->time_utc_usec = 0;
 		}
 
 		_gps_position->timestamp = gps_absolute_time();
@@ -2536,6 +2542,12 @@ GPSDriverUBX::payloadRxDone()
 #else
 			_gps_position->time_utc_usec = 0;
 #endif
+
+		} else {
+			// The struct is reused across messages, so without this a receiver
+			// that lost time in a reset keeps reporting the last time it knew.
+			// 0 is the defined "unavailable" value.
+			_gps_position->time_utc_usec = 0;
 		}
 
 		_last_timestamp_time = gps_absolute_time();

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1040,6 +1040,11 @@ public:
 		int8_t min_elev;
 		uint8_t output_rate;
 		float heading_offset;
+		// Target baudrate for the receiver's UART1, applied after the link is
+		// auto-detected. 0 keeps the driver default (115200; heading modes
+		// 921600). Unlike a fixed baudrate this never prevents connecting to a
+		// receiver still at its power-on default.
+		int32_t uart1_baudrate;
 		int32_t uart2_baudrate;
 		bool ppk_output;
 		bool jam_det_sensitivity_hi;
@@ -1262,6 +1267,7 @@ private:
 
 	const UBXMode _mode {};
 	const float _heading_offset {};
+	const int32_t _uart1_baudrate {};
 	const int32_t _uart2_baudrate {};
 	const bool _ppk_output {};
 	const bool _jam_det_sensitivity_hi {};


### PR DESCRIPTION
## Summary
Zeroes `time_utc_usec` whenever NAV-PVT/NAV-TIMEUTC time validity flags are not set, and adds an optional `uart1_baudrate` target applied after baudrate auto-detection.

## Problem
The position struct is reused across messages, so after a receiver reset the driver keeps republishing the last UTC time it knew even though the receiver no longer knows the time. `sensor_gps` defines 0 as time-unavailable, and downstream consumers (e.g. an AssistNow client watching for receiver restarts over MAVLink) need the distinction between a fix flap, which keeps time, and a restart, which loses it.

Separately, raising the UART1 link rate today requires a fixed baudrate, which restricts the probe scan to that single rate — it asserts the receiver is already there, so a receiver at its power-on default can never be connected to.

## Solution
Add the missing `else` branches so invalid receiver time is published as 0. Add `settings.uart1_baudrate`: when nonzero it only replaces the rate both ends move to after the link is auto-detected, the same way the heading modes already force 921600, so it can never lock the driver out of a receiver at its default rate. Verified on a ZED-X20P (HPG 2.10) cannode: autobaud found the receiver at 115200 and moved the link to 921600, clean injection and 10 Hz output.