### PR TITLE
fix(ubx): use uart1_baudrate as the only UART1 target

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -120,13 +120,10 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 		unsigned baud_i;
 		unsigned desired_baudrate = auto_baudrate ? UBX_BAUDRATE_M8_AND_NEWER : baudrate;
 
-		if ((_mode == UBXMode::RoverWithMovingBaseUART1) || (_mode == UBXMode::MovingBaseUART1)) {
-			desired_baudrate = UART1_BAUDRATE_HEADING;
-		}
-
-		// An explicit UART1 target wins. The probe scan is unaffected, so this
-		// cannot lock the driver out of a receiver at its power-on default the
-		// way a fixed baudrate does.
+		// uart1_baudrate (GPS_UBX_BAUD1) is the sole UART1 target after auto-detect.
+		// 0 keeps the driver default (115200). The probe scan is unaffected, so this
+		// cannot lock the driver out of a receiver at its power-on default the way a
+		// fixed baudrate does.
 		if (_uart1_baudrate > 0) {
 			desired_baudrate = _uart1_baudrate;
 		}

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -68,8 +68,6 @@
 #define UBX_SYNC1             0xB5
 #define UBX_SYNC2             0x62
 
-#define UART1_BAUDRATE_HEADING 921600
-
 /* Message Classes */
 #define UBX_CLASS_NAV         0x01
 #define UBX_CLASS_RXM         0x02
@@ -1041,9 +1039,9 @@ public:
 		uint8_t output_rate;
 		float heading_offset;
 		// Target baudrate for the receiver's UART1, applied after the link is
-		// auto-detected. 0 keeps the driver default (115200; heading modes
-		// 921600). Unlike a fixed baudrate this never prevents connecting to a
-		// receiver still at its power-on default.
+		// auto-detected. 0 keeps the driver default (115200). Unlike a fixed
+		// baudrate this never prevents connecting to a receiver still at its
+		// power-on default.
 		int32_t uart1_baudrate;
 		int32_t uart2_baudrate;
 		bool ppk_output;


### PR DESCRIPTION
## Summary

Make `uart1_baudrate` (`GPS_UBX_BAUD1`) the sole post-detect UART1 target in all UBX modes, including heading modes 3/4.

## Problem

Modes 3/4 hard-coded UART1 to 921600 when `uart1_baudrate` was 0. That is unreliable on setups where GPS UART1 runs over a longer serial cable to the flight controller, and it fought the purpose of the new configurable target.

## Solution

Remove the heading-mode baud override. `uart1_baudrate > 0` sets the target after auto-detect; 0 keeps the driver default (115200). Boards that need 921600 (on-module short runs) set `GPS_UBX_BAUD1` in board defaults.