### PR TITLE
fix(ubx): stop unsupported config keys from taking the whole receiver down

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1149,18 +1149,25 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset(RTCM_MSM7_UART2, _ppk_output ? 1 : 0);
 		cfgValset(RTCM_MSM4_UART2, _ppk_output ? 0 : 1);
 
-		// 4072.0 marks the base as moving, without it the rover solves against it as a
-		// static base and never reports a heading. The F9P-15B doesn't support 4072.
-		if (_board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox_X20) {
-			UBX_DEBUG("Configuring ublox 4072");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1);
-		}
-
 		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
 		GPS_INFO("UART2: RTCM3 out @ %d baud (rover)", (int)uart2_baudrate);
+
+		// 4072.0 marks the base as moving, without it the rover solves against it as a
+		// static base and never reports a heading. The F9P-15B doesn't support 4072, and
+		// neither does the X20 before HPG 2.10, so it goes out on its own: losing the
+		// heading is bad, losing the receiver is worse.
+		if (_board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox_X20) {
+			UBX_DEBUG("Configuring ublox 4072");
+			initCfgValset();
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1);
+
+			if (sendCfgValsetAcked(false) < 0) {
+				UBX_WARN("RTCM 4072.0 not supported, no moving base heading");
+			}
+		}
 
 	} else if (_mode == UBXMode::RoverWithMovingBaseUART1) {
 		UBX_DEBUG("Configuring UART1 for rover");
@@ -1196,15 +1203,22 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset(RTCM_MSM7_UART1, _ppk_output ? 1 : 0);
 		cfgValset(RTCM_MSM4_UART1, _ppk_output ? 0 : 1);
 
-		// 4072.0 marks the base as moving, without it the rover solves against it as a
-		// static base and never reports a heading. The F9P-15B doesn't support 4072.
-		if (_board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox_X20) {
-			UBX_DEBUG("Configuring ublox 4072");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1, 1);
-		}
-
 		if (sendCfgValsetAcked() < 0) {
 			return -1;
+		}
+
+		// 4072.0 marks the base as moving, without it the rover solves against it as a
+		// static base and never reports a heading. The F9P-15B doesn't support 4072, and
+		// neither does the X20 before HPG 2.10, so it goes out on its own: losing the
+		// heading is bad, losing the receiver is worse.
+		if (_board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox_X20) {
+			UBX_DEBUG("Configuring ublox 4072");
+			initCfgValset();
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1, 1);
+
+			if (sendCfgValsetAcked(false) < 0) {
+				UBX_WARN("RTCM 4072.0 not supported, no moving base heading");
+			}
 		}
 
 	} else if (_mode == UBXMode::GroundControlStation) {

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -712,16 +712,16 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 
-	initCfgValset();
+	// enable jamming monitor. CFG-ITFM is gone on the F9 L1L5 and F20 platforms, those
+	// report interference through CFG-SEC-JAMDET instead
+	if (_board != Board::u_blox9_F9P_L1L5 && _board != Board::u_blox_X20) {
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1);
 
-	// enable jamming monitor
-	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1);
-
-	if (!sendCfgValset()) {
-		return -1;
+		if (sendCfgValsetAcked(false) < 0) {
+			UBX_WARN("Jamming monitor not supported by this receiver");
+		}
 	}
-
-	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 
 	// configure jamming detection sensitivity (CFG-SEC-JAMDET_SENSITIVITY_HI)
 	// Note: This configuration key may not be supported on older firmware versions.

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -523,6 +523,13 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 			// once. Keep the receiver's own selection rather than losing the fix over it.
 			UBX_WARN("GNSS constellation config rejected, keeping receiver config");
 		}
+
+		// On u-blox 8 the Galileo change only takes effect once the configuration has been
+		// saved and the receiver hardware reset, which we cannot do without dropping the
+		// rest of this session's configuration
+		if (gnssSystems & GNSSSystemsMask::ENABLE_GALILEO) {
+			UBX_WARN("Galileo needs a receiver power cycle to take effect");
+		}
 	}
 
 	/* configure message rates */

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -745,8 +745,12 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, 1);
 			UBX_DEBUG("GNSS Systems: Enable QZSS L1CA");
 			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L1CA_ENA, 1);
-			UBX_DEBUG("GNSS Systems: Enable QZSS L1S");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L1S_ENA, 1);
+
+			// M9 (SPG) has no CFG-SIGNAL key for QZSS L1S
+			if (_board != Board::u_blox9) {
+				UBX_DEBUG("GNSS Systems: Enable QZSS L1S");
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L1S_ENA, 1);
+			}
 
 			if (_board == Board::u_blox_X20) {
 				UBX_DEBUG("GNSS Systems: Use GPS L2C + L5, QZSS L2C + L5");
@@ -909,9 +913,38 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			}
 		}
 
-		if (sendCfgValsetAcked() < 0) {
-			UBX_DEBUG("UBX GNSS config failed");
+		if (!sendCfgValset()) {
+			UBX_DEBUG("UBX GNSS config send failed");
 			return -1;
+		}
+
+		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+			// The receiver NAKs the whole message and applies nothing if it does not know a
+			// single key, so a signal key missing on this generation would leave the receiver
+			// unconfigured. Retry with the constellation enables, those exist everywhere.
+			UBX_WARN("GNSS signal config rejected, retrying without signal bands");
+
+			initCfgValset();
+
+			const uint8_t use_gps = (config.gnss_systems & GNSSSystemsMask::ENABLE_GPS) ? 1 : 0;
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_ENA, use_gps);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, use_gps);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_ENA, (config.gnss_systems & GNSSSystemsMask::ENABLE_GALILEO) ? 1 : 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_ENA, (config.gnss_systems & GNSSSystemsMask::ENABLE_BEIDOU) ? 1 : 0);
+
+			if (_board != Board::u_blox10_L1L5 && _board != Board::u_blox_X20) {
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_ENA, (config.gnss_systems & GNSSSystemsMask::ENABLE_GLONASS) ? 1 : 0);
+			}
+
+			if (!sendCfgValset()) {
+				return -1;
+			}
+
+			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+				// Keep going with whatever the receiver already has, a refused constellation
+				// selection must not cost us the fix
+				UBX_WARN("GNSS constellation config rejected, keeping receiver config");
+			}
 		}
 
 		// send SBAS config separately, because it seems to be buggy (with u-center, too)

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -691,11 +691,14 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	// Disable odometer. Separate, non-fatal VALSET: CFG-ODO-* was removed on the
 	// F20 platform (ZED-X20P HPG 2.10+), so a NAK here must not abort config.
-	static constexpr uint32_t odo_keys[] = {
-		UBX_CFG_KEY_ODO_USE_ODO, UBX_CFG_KEY_ODO_USE_COG, UBX_CFG_KEY_ODO_OUTLPVEL, UBX_CFG_KEY_ODO_OUTLPCOG
-	};
 	initCfgValset();
-	cfgValset(odo_keys, 0);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0);
+
+	// M9 (SPG) only has USE_ODO and PROFILE in CFG-ODO
+	if (_board != Board::u_blox9) {
+		static constexpr uint32_t odo_keys[] = {UBX_CFG_KEY_ODO_USE_COG, UBX_CFG_KEY_ODO_OUTLPVEL, UBX_CFG_KEY_ODO_OUTLPCOG};
+		cfgValset(odo_keys, 0);
+	}
 
 	sendCfgValsetAcked(false);
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -518,8 +518,10 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 		}
 
 		if (waitForAck(UBX_MSG_CFG_GNSS, UBX_CONFIG_TIMEOUT, true) < 0) {
-			UBX_DEBUG("UBX CFG-GNSS message ACK failed");
-			return -1;
+			// The receiver rejects the configuration as a whole if it names a constellation it
+			// cannot receive, e.g. BeiDou on a SAM-M8Q, or more of them than it can track at
+			// once. Keep the receiver's own selection rather than losing the fix over it.
+			UBX_WARN("GNSS constellation config rejected, keeping receiver config");
 		}
 	}
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1001,18 +1001,28 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1);
 	}
 
+	if (sendCfgValsetAcked() < 0) {
+		return -1;
+	}
+
 	// Explicitly disable the messages this driver never consumes. We do not enable them,
 	// but they can be left on in the receiver's non-volatile config by other software
 	// (u-center, or another firmware such as ArduPilot, which writes CFG-VALSET to the
 	// BBR/FLASH layers). Clearing them here rather than waiting for payloadRxInit() to
 	// notice them avoids wasting UART bandwidth on every boot.
-	static constexpr uint32_t unused_msgout[] = {
-		UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C, UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C, UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C
-	};
-	cfgValsetPort(unused_msgout, 0);
+	// Separate, non-fatal VALSET: these messages do not exist on every generation, and
+	// bandwidth we failed to save is not worth losing the receiver over.
+	initCfgValset();
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C, 0);
 
-	if (sendCfgValsetAcked() < 0) {
-		return -1;
+	// M10 and F10 have no raw measurement output
+	if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C, 0);
+	}
+
+	if (sendCfgValsetAcked(false) < 0) {
+		UBX_WARN("Could not disable unused messages");
 	}
 
 	// Dual antenna heading, not used in a moving base setup where NAV-RELPOSNED provides it. The rate is

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -530,6 +530,8 @@ int GPSDriverUBX::configureDevicePreV27(const GNSSSystemsMask &gnssSystems)
 		if (gnssSystems & GNSSSystemsMask::ENABLE_GALILEO) {
 			UBX_WARN("Galileo needs a receiver power cycle to take effect");
 		}
+
+		waitForGnssReset();
 	}
 
 	/* configure message rates */
@@ -954,6 +956,8 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			}
 		}
 
+		waitForGnssReset();
+
 		// send SBAS config separately, because it seems to be buggy (with u-center, too)
 		initCfgValset();
 
@@ -971,6 +975,8 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		}
 
 		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true);
+
+		waitForGnssReset();
 	}
 
 	// GPS L5 is broadcast unhealthy while it is pre-operational, so tell the receiver to take
@@ -1632,6 +1638,19 @@ GPSDriverUBX::waitForAck(const uint16_t msg, const unsigned timeout, const bool 
 
 	_ack_state = UBX_ACK_IDLE;
 	return ret;
+}
+
+void
+GPSDriverUBX::waitForGnssReset()
+{
+	// Changing the enabled constellations resets the GNSS subsystem, and every u-blox
+	// interface description asks for 0.5 s after the acknowledgement before the next
+	// command. Keep reading while we wait, the receiver is still streaming.
+	const gps_abstime time_started = gps_absolute_time();
+
+	while (gps_absolute_time() < time_started + UBX_GNSS_RESET_TIME) {
+		receive(UBX_CONFIG_TIMEOUT);
+	}
 }
 
 int	// -1 = error, 0 = no message handled, 1 = message handled, 2 = sat info message handled

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -758,7 +758,6 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 				UBX_DEBUG("GNSS Systems: Use GPS L2C + L5, QZSS L2C + L5");
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 1);
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 1);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1);
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L2C_ENA, 1);
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L5_ENA, 1);
 
@@ -771,8 +770,6 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Use GPS L5");
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 1);
-				UBX_DEBUG("GNSS Systems: Enable GPS L5 health override");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1);
 				UBX_DEBUG("GNSS Systems: Use QZSS L5");
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L5_ENA, 1);
 			}
@@ -787,7 +784,6 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 				UBX_DEBUG("GNSS Systems: Disable GPS L2C + L5");
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 0);
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 0);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 0);
 
 			} else if (_board == Board::u_blox9_F9P_L1L2) {
 				UBX_DEBUG("GNSS Systems: Disable GPS L2C");
@@ -796,7 +792,6 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Disable GPS L5");
 				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 0);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 0);
 			}
 		}
 
@@ -966,19 +961,24 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		}
 
 		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true);
+	}
 
-	} else if (_board == Board::u_blox10_L1L5 || _board == Board::u_blox_X20) {
-		// Enable L5 health override, use version 0 of the message
+	// GPS L5 is broadcast unhealthy while it is pre-operational, so tell the receiver to take
+	// the L1 health flag instead. The key is not in any interface description, only in app note
+	// UBX-21038688, so it gets a message of its own rather than putting the constellation
+	// config at the mercy of a firmware that has never heard of it.
+	if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5 || _board == Board::u_blox_X20) {
+		const bool use_gps = (static_cast<int32_t>(config.gnss_systems) == 0)
+				     || (config.gnss_systems & GNSSSystemsMask::ENABLE_GPS);
+
+		UBX_DEBUG("%s L5 health override", use_gps ? "Enabling" : "Disabling");
+
 		initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, use_gps ? 1 : 0);
 
-		UBX_DEBUG("Enabling L5 health override");
-
-		if (!sendCfgValset()) {
-			return -1;
+		if (sendCfgValsetAcked(false) < 0) {
+			UBX_WARN("GPS L5 health override not supported by this receiver");
 		}
-
-		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true);
 	}
 
 	// Configure message rates

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -53,6 +53,7 @@
 
 
 #define UBX_CONFIG_TIMEOUT    250 // ms, timeout for waiting ACK
+#define UBX_GNSS_RESET_TIME   500000 // us, GNSS subsystem reset after a constellation change
 #define UBX_PACKET_TIMEOUT    8   // ms, if now data during this delay assume that full update received
 
 // Dedicated TX buffer for CFG-VALSET. Sized independently of ubx_buf_t (the RX
@@ -1291,6 +1292,11 @@ private:
 	 * Wait for message acknowledge
 	 */
 	int waitForAck(const uint16_t msg, const unsigned timeout, const bool report);
+
+	/**
+	 * Wait out the GNSS subsystem reset that follows a constellation change
+	 */
+	void waitForGnssReset();
 
 	const Interface _interface{};
 


### PR DESCRIPTION
## Summary
fixes PX4/PX4-Autopilot#27765

Started as a fix for a NEO-M9N reporting no satellites on any non-zero `GPS_x_GNSS`, then turned into an audit of every configuration key this driver sends against the interface descriptions for M8 (UBX-13003221), M9 SPG 4.04, F9 HPG 1.32, F9 HPG L1L5 1.40, M10 SPG 5.10, F10 SPG 6.00 and X20 HPG 2.00/2.10. Several more receivers are broken the same way, including one that is broken on current main.

One commit per finding. Compile tested only, no bench time on any of these receivers yet.

## Problem
`UBX-CFG-VALSET` is rejected as a whole and applies nothing "if any key is unknown to the receiver FW", and `UBX-CFG-GNSS` behaves the same way for a constellation set the receiver cannot honour. The driver builds large messages that mix keys every generation has with keys only some generations have, and then treats the NAK as fatal — `configureDevice()` returns -1, the configure loop restarts, and the receiver never reports a satellite. A parameter the user is invited to set is enough to trigger it:

- **M9**: `CFG-SIGNAL-QZSS_L1S_ENA` (0x10310014) is not in the M9 `CFG-SIGNAL` group, L1S is handled through `CFG-QZSS-USE_SLAS_*` there. Sent since #181 whenever the GPS bit is set, so every non-zero `GPS_x_GNSS` killed a NEO-M9N. This is the reported bug.
- **M10 and F10, on main only**: `UBX-RXM-RAWX` does not exist on either platform, so `CFG-MSGOUT-UBX_RXM_RAWX_*` is not in their configuration database. #219 put that key in the fatal message-rate VALSET for every board, which takes out MAX-M10S, SAM-M10Q and DAN-F10N with no parameter needed. Not in v1.17 or v1.18.
- **u-blox 8**: a SAM-M8Q receives GPS, Galileo and GLONASS only, so any mask with the BeiDou bit is refused and `configureDevicePreV27()` gives up.
- **X20 on HPG 2.00**: `CFG-MSGOUT-RTCM_3X_TYPE4072_0_*` only exists from HPG 2.10, so configuring a moving base cost the whole receiver rather than just the heading.
- **X20, F9P-15B, DAN-F10N**: `CFG-SIGNAL-L5_HEALTH_OVERRIDE` (0x10320001) is in no interface description at all, only in app note UBX-21038688, and it was riding in the same message as the constellation config.

Three quieter ones: the M9 `CFG-ODO` group has only `USE_ODO` and `PROFILE`, so the odometer was never actually disabled there; `CFG-ITFM` is gone on the F9 L1L5 and F20 platforms, so the jamming monitor write was silently dropped with the ack discarded; and every interface description asks for 0.5 s after a constellation change before the next command, which the driver never waited.

## Solution
Keys whose existence varies by generation no longer travel with keys that must land, and a refused preference no longer costs the fix.

Per receiver: skip QZSS L1S on M9, skip RXM-RAWX on M10/F10, send the L5 health override and the moving base 4072.0 rate in messages of their own, send only the CFG-ODO keys an M9 has, and skip CFG-ITFM where the group was removed.

Per failure: if the signal message is refused anyway, retry with the constellation enables alone, which every generation supports; if that is refused too, keep the receiver's own configuration and say so. Same for CFG-GNSS on u-blox 8. The settle wait reads the port rather than sleeping on it, since the receiver is still streaming.

Two things this does not fix. Galileo on u-blox 8 needs a configuration save and a hardware reset to take effect, which cannot be done mid-configuration without dropping everything else already written, so the driver now warns instead. And `GPS_UBX_DYNMODEL` accepts 1 (reserved on every generation) and 9 (not on all products), either of which NAKs a message that is still fatal — that range lives in PX4-Autopilot, not here.


