### PR TITLE
fix(ubx): read svUsed from the correct flags bit in NAV-SAT and NAV-SVINFO

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2094,11 +2094,9 @@ GPSDriverUBX::payloadRxAddNavSat(const uint8_t b)
 				_satellite_info->svid[sat_index]	  = svinfo_svid;
 				// NAV-SAT flags: bits 2..0 qualityInd, bit 3 svUsed
 				_satellite_info->used[sat_index]	  = static_cast<uint8_t>((_buf.payload_rx_nav_sat_part2.flags >> 3) & 0x01);
-				// TODO: elev (I1, +/-90, out of range = unknown) and azim (I2) are stored unsigned in
-				// satellite_info, so negatives wrap: -91 deg elevation publishes as 165, and a negative
-				// azim scaled by 255/360 is a UB float->unsigned conversion. Needs SatelliteInfo.msg to
-				// carry signed angles and an unknown marker; clamping here would only turn "unknown"
-				// into "on the horizon". Its elevation comment is inverted too (90 is overhead, not 0).
+				// TODO: elev and azim are signed on the wire but unsigned in satellite_info, so
+				// negatives wrap. Needs SatelliteInfo.msg to carry signed angles and an unknown
+				// marker; its elevation comment is inverted too.
 				_satellite_info->elevation[sat_index] = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.elev);
 				_satellite_info->azimuth[sat_index]	  = static_cast<uint8_t>(static_cast<float>(_buf.payload_rx_nav_sat_part2.azim) *
 						255.0f / 360.0f);

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2092,7 +2092,8 @@ GPSDriverUBX::payloadRxAddNavSat(const uint8_t b)
 				}
 
 				_satellite_info->svid[sat_index]	  = svinfo_svid;
-				_satellite_info->used[sat_index]	  = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.flags & 0x01);
+				// NAV-SAT flags: bits 2..0 qualityInd, bit 3 svUsed
+				_satellite_info->used[sat_index]	  = static_cast<uint8_t>((_buf.payload_rx_nav_sat_part2.flags >> 3) & 0x01);
 				_satellite_info->elevation[sat_index] = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.elev);
 				_satellite_info->azimuth[sat_index]	  = static_cast<uint8_t>(static_cast<float>(_buf.payload_rx_nav_sat_part2.azim) *
 						255.0f / 360.0f);
@@ -2151,7 +2152,8 @@ GPSDriverUBX::payloadRxAddNavSvinfo(const uint8_t b)
 				unsigned sat_index = (_rx_payload_index - sizeof(ubx_payload_rx_nav_svinfo_part1_t)) /
 						     sizeof(ubx_payload_rx_nav_svinfo_part2_t);
 				_satellite_info->svid[sat_index]      = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.svid);
-				_satellite_info->used[sat_index]      = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.flags >> 3 & 0x01);
+				// NAV-SVINFO flags: bit 0 svUsed
+				_satellite_info->used[sat_index]      = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.flags & 0x01);
 				_satellite_info->elevation[sat_index] = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.elev);
 				_satellite_info->azimuth[sat_index]   = static_cast<uint8_t>(static_cast<float>(_buf.payload_rx_nav_svinfo_part2.azim) *
 									255.0f / 360.0f);

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2094,6 +2094,11 @@ GPSDriverUBX::payloadRxAddNavSat(const uint8_t b)
 				_satellite_info->svid[sat_index]	  = svinfo_svid;
 				// NAV-SAT flags: bits 2..0 qualityInd, bit 3 svUsed
 				_satellite_info->used[sat_index]	  = static_cast<uint8_t>((_buf.payload_rx_nav_sat_part2.flags >> 3) & 0x01);
+				// TODO: elev (I1, +/-90, out of range = unknown) and azim (I2) are stored unsigned in
+				// satellite_info, so negatives wrap: -91 deg elevation publishes as 165, and a negative
+				// azim scaled by 255/360 is a UB float->unsigned conversion. Needs SatelliteInfo.msg to
+				// carry signed angles and an unknown marker; clamping here would only turn "unknown"
+				// into "on the horizon". Its elevation comment is inverted too (90 is overhead, not 0).
 				_satellite_info->elevation[sat_index] = static_cast<uint8_t>(_buf.payload_rx_nav_sat_part2.elev);
 				_satellite_info->azimuth[sat_index]	  = static_cast<uint8_t>(static_cast<float>(_buf.payload_rx_nav_sat_part2.azim) *
 						255.0f / 360.0f);
@@ -2154,6 +2159,7 @@ GPSDriverUBX::payloadRxAddNavSvinfo(const uint8_t b)
 				_satellite_info->svid[sat_index]      = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.svid);
 				// NAV-SVINFO flags: bit 0 svUsed
 				_satellite_info->used[sat_index]      = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.flags & 0x01);
+				// TODO: same elev/azim wrap as NAV-SAT above
 				_satellite_info->elevation[sat_index] = static_cast<uint8_t>(_buf.payload_rx_nav_svinfo_part2.elev);
 				_satellite_info->azimuth[sat_index]   = static_cast<uint8_t>(static_cast<float>(_buf.payload_rx_nav_svinfo_part2.azim) *
 									255.0f / 360.0f);

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -606,7 +606,7 @@ typedef struct {
 	int8_t   elev;           /**< Elevation [deg] range: +/-90 */
 	int16_t  azim;           /**< Azimuth [deg] range: 0-360 */
 	int16_t  prRes;          /**< Pseudo range residual [0.1 m] */
-	uint32_t flags;
+	uint32_t flags;          /**< bits 2..0 qualityInd, bit 3 svUsed, bits 5..4 health, bit 6 diffCorr, bit 7 smoothed */
 } ubx_payload_rx_nav_sat_part2_t;
 
 /* Rx NAV-STATUS */


### PR DESCRIPTION
## Summary

`satellite_info.used[]` is decoded from the wrong bit of the u-blox flags word, in both the NAV-SAT and the NAV-SVINFO parser. Affects every u-blox receiver with `GPS_SAT_INFO` enabled, and surfaces as MAVLink `GPS_STATUS.satellite_used`.

## Problem

NAV-SAT packs `qualityInd` in bits 2..0 and `svUsed` in bit 3, but the parser reads bit 0 — so what it publishes is the LSB of `qualityInd`. A satellite that is only searching counts as used; one that is code locked and time synchronized does not. It looks right most of the time because `qualityInd` 7 dominates on healthy satellites, which is why it went unnoticed.

NAV-SVINFO is the mirror image: `svUsed` is bit 0 and `orbitEph` is bit 3, and the parser reads bit 3.

They got swapped because NAV-SAT was added by copying the then-correct SVINFO parser, and a later "fixed wrong mapping" commit shifted the wrong one of the pair.

## Solution

Read bit 3 for NAV-SAT and bit 0 for NAV-SVINFO, per the F9 HPG 1.51 and X20 HPG 2.10 interface descriptions. NAV-SAT covers M9/M10/F9/X20, NAV-SVINFO the legacy M6/M7/M8 path. The scalar `satellites_used` from NAV-PVT `numSV` is a different field and was already correct.

Out of scope: `elev` and `azim` are signed on the wire and unsigned in `satellite_info`, so negatives wrap. Fixing that means changing `SatelliteInfo.msg` alongside the driver; a TODO marks it.
