### PR TITLE
feat(ubx): add u-center diagnostics mode on UART2

### DIFF
--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1234,6 +1234,70 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
 			return -1;
 		}
+
+	} else if (_mode == UBXMode::UCenterUART2) {
+		// Diagnostic port. UART1 keeps carrying the flight controller's own session, UART2 gets
+		// UBX in both directions so u-center can watch and poll the receiver. Nothing below is
+		// fatal: a debug port that will not come up must not cost us the GPS.
+		if (_board == Board::u_blox10 || _board == Board::u_blox10_L1L5) {
+			UBX_WARN("Receiver has no UART2, u-center mode not configured");
+
+		} else {
+			UBX_DEBUG("Configuring UART2 for u-center");
+
+			// On its own, because the platforms that wire UART2 permanently on have no such key
+			// and a NAK would otherwise take the port settings down with it.
+			cfg_valset_msg_size = initCfgValset();
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_ENABLED, 1, cfg_valset_msg_size);
+
+			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+				(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
+			}
+
+			cfg_valset_msg_size = initCfgValset();
+			cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
+			// Input stays open so u-center can poll MON-VER and drive the configuration view
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+
+			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+				if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
+					UBX_WARN("UART2 port config for u-center rejected");
+				}
+			}
+
+			// Message rates are per port, so the set enabled for the driver's own port leaves UART2
+			// silent. u-center shows nothing at all without these.
+			cfg_valset_msg_size = initCfgValset();
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1, cfg_valset_msg_size);
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_STATUS_I2C, 1, cfg_valset_msg_size);
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1, cfg_valset_msg_size);
+			// NAV-SAT is 12 bytes per satellite against ~250 for all of the above together, so it
+			// gets the same decimation the driver uses for itself rather than setting the link speed
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, 10, cfg_valset_msg_size);
+
+			if (_board != Board::u_blox9) {
+				cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1, cfg_valset_msg_size);
+			}
+
+			if (_board == Board::u_blox9 || _board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox9_F9P_L1L5) {
+				cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1, cfg_valset_msg_size);
+			}
+
+			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+				if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
+					UBX_WARN("UART2 message rates for u-center rejected");
+				}
+			}
+		}
 	}
 
 	return 0;
@@ -1288,6 +1352,11 @@ bool GPSDriverUBX::cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size)
 	}
 
 	return true;
+}
+
+bool GPSDriverUBX::cfgValsetUart2(uint32_t key_id, uint8_t value, int &msg_size)
+{
+	return cfgValset<uint8_t>(key_id + 2, value, msg_size);
 }
 
 int GPSDriverUBX::restartSurveyInPreV27()

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1243,7 +1243,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			UBX_WARN("Receiver has no UART2, u-center mode not configured");
 
 		} else {
-			UBX_DEBUG("Configuring UART2 for u-center");
+			GPS_INFO("Configuring UART2 for u-center");
 
 			// On its own, because the platforms that wire UART2 permanently on have no such key
 			// and a NAK would otherwise take the port settings down with it.

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1089,6 +1089,9 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			return -1;
 		}
 
+		GPS_INFO("UART2: RTCM3 in @ %d baud (%s)", (int)uart2_baudrate,
+			 _mode == UBXMode::RoverWithMovingBaseUART2 ? "moving base" : "static base");
+
 	} else if (_mode == UBXMode::MovingBaseUART2) {
 		UBX_DEBUG("Configuring UART2 for moving base");
 		// enable RTCM output on uart2 + set baudrate
@@ -1143,6 +1146,8 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
 			return -1;
 		}
+
+		GPS_INFO("UART2: RTCM3 out @ %d baud (rover)", (int)uart2_baudrate);
 
 	} else if (_mode == UBXMode::RoverWithMovingBaseUART1) {
 		UBX_DEBUG("Configuring UART1 for rover");
@@ -1235,6 +1240,8 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			return -1;
 		}
 
+		GPS_INFO("UART2: NMEA out @ %d baud (ground control station)", (int)uart2_baudrate);
+
 	} else if (_mode == UBXMode::UCenterUART2) {
 		// Diagnostic port. UART1 keeps carrying the flight controller's own session, UART2 gets
 		// UBX in both directions so u-center can watch and poll the receiver. Nothing below is
@@ -1243,8 +1250,6 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			UBX_WARN("Receiver has no UART2, u-center mode not configured");
 
 		} else {
-			GPS_INFO("Configuring UART2 for u-center");
-
 			// On its own, because the platforms that wire UART2 permanently on have no such key
 			// and a NAK would otherwise take the port settings down with it.
 			cfg_valset_msg_size = initCfgValset();
@@ -1297,10 +1302,32 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 					UBX_WARN("UART2 message rates for u-center rejected");
 				}
 			}
+
+			GPS_INFO("UART2: UBX in/out @ %d baud (u-center)", (int)uart2_baudrate);
 		}
 	}
 
 	return 0;
+}
+
+const char *GPSDriverUBX::uart1Protocols(UBXMode mode, bool ppk_output)
+{
+	switch (mode) {
+	case UBXMode::Normal: return ppk_output ? "UBX in/out + RTCM3 out" : "UBX in/out";
+
+	case UBXMode::RoverWithMovingBaseUART2:
+	case UBXMode::RoverWithStaticBaseUART2: return "UBX out";
+
+	case UBXMode::RoverWithMovingBaseUART1: return "UBX in/out + RTCM3 in";
+
+	case UBXMode::MovingBaseUART1: return "UBX in/out + RTCM3 in/out";
+
+	case UBXMode::MovingBaseUART2:
+	case UBXMode::GroundControlStation:
+	case UBXMode::UCenterUART2: return "UBX in/out";
+	}
+
+	return "UBX in/out";
 }
 
 int GPSDriverUBX::initCfgValset()

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1029,6 +1029,7 @@ public:
 		MovingBaseUART1,           ///< moving base; outputs RTCM on UART1 (relayed to the rover via the flight controller)
 		RoverWithStaticBaseUART2,  ///< heading rover; receives static-base RTCM on UART2
 		GroundControlStation,      ///< NMEA output to a ground control station (GPS is installed in the GCS)
+		UCenterUART2,              ///< UBX diagnostics on UART2 for u-center, while the driver keeps UART1
 	};
 
 	struct Settings {
@@ -1159,6 +1160,17 @@ private:
 	 * @return true on success, false if buffer too small
 	 */
 	bool cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size);
+
+	/**
+	 * Add a port-specific (MSGOUT) configuration value for UART2, which is never the port this
+	 * driver talks on. Same key ordering assumption as cfgValsetPort().
+	 *
+	 * @param key_id I2C key ID
+	 * @param value configuration value
+	 * @param msg_size CFG-VALSET message size: this is an input & output param
+	 * @return true on success, false if buffer too small
+	 */
+	bool cfgValsetUart2(uint32_t key_id, uint8_t value, int &msg_size);
 
 	/**
 	 * Reset the parse state machine for a fresh start

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1090,6 +1090,11 @@ public:
 
 	const Board &board() const { return _board; }
 
+	/**
+	 * What UART1 carries in a given mode, for status output
+	 */
+	static const char *uart1Protocols(UBXMode mode, bool ppk_output);
+
 private:
 	int activateRTCMOutput(bool reduce_update_rate);
 


### PR DESCRIPTION
## Summary

Adds a u-blox mode that turns the receiver's UART2 into a UBX diagnostic port for u-center while the driver keeps its own session on UART1. Exposed as `GPS_UBX_MODE` 7 by the companion PX4 PR.

## Problem

`uart2_baudrate` only ever reaches the receiver inside the RTCM branches (`RoverWithMovingBaseUART2`, `MovingBaseUART2`, `RoverWithStaticBaseUART2`) and `GroundControlStation`. Every other mode sends no `CFG-UART2-*` key at all, so the setting is read and discarded and a serial adapter on UART2 sees nothing. Looking at a receiver with u-center means stopping the driver and taking over UART1.

`GroundControlStation` is the one mode that produces output on UART2, and it is NMEA with all three input protocols disabled, so u-center cannot poll the receiver or open its configuration view over that port either.

## Solution

`UBXMode::UCenterUART2` brings UART2 up at `uart2_baudrate` 8N1 with UBX enabled in both directions, then enables the diagnostic message set on that port: `NAV-PVT`, `NAV-DOP`, `NAV-STATUS` and `MON-RF` every epoch, `NAV-HPPOSLLH` and `RXM-RTCM` where the generation has them, and `NAV-SAT` every tenth epoch since it dwarfs the rest. Message output rates are per port, so without that last step u-center connects to a silent link even with `UART2OUTPROT-UBX` set — the rates `cfgValsetPort()` writes only cover the port the driver itself talks on.

`CFG-UART2-ENABLED` goes out in a VALSET of its own, because platforms that wire UART2 permanently on have no such key and a NAK would otherwise take the port settings with it. All three writes are non-fatal: a diagnostic port that will not come up must not abort configuration and cost us the GPS. The mode is skipped with a warning on M10 and F10, which have no UART2.
