### PR TITLE
refactor(ubx,nmea): shrink the drivers by ~4 KB of flash

### DIFF
--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -109,17 +109,17 @@ int GPSDriverAshtech::handleMessage(int len)
 		ASH_UNUSED(local_time_off_min);
 		ASH_UNUSED(local_time_off_hour);
 
-		if (bufptr && *(++bufptr) != ',') { ashtech_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ashtech_time);
 
-		if (bufptr && *(++bufptr) != ',') { day = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, day);
 
-		if (bufptr && *(++bufptr) != ',') { month = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, month);
 
-		if (bufptr && *(++bufptr) != ',') { year = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, year);
 
-		if (bufptr && *(++bufptr) != ',') { local_time_off_hour = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, local_time_off_hour);
 
-		if (bufptr && *(++bufptr) != ',') { local_time_off_min = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, local_time_off_min);
 
 		int ashtech_hour = static_cast<int>(ashtech_time / 10000);
 		int ashtech_minute = static_cast<int>((ashtech_time - ashtech_hour * 10000) / 100);
@@ -213,23 +213,23 @@ int GPSDriverAshtech::handleMessage(int len)
 		ASH_UNUSED(num_of_sv);
 		ASH_UNUSED(hdop);
 
-		if (bufptr && *(++bufptr) != ',') { ashtech_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ashtech_time);
 
-		if (bufptr && *(++bufptr) != ',') { lat = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lat);
 
-		if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+		nmeaNextField(bufptr, ns);
 
-		if (bufptr && *(++bufptr) != ',') { lon = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lon);
 
-		if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++); }
+		nmeaNextField(bufptr, ew);
 
-		if (bufptr && *(++bufptr) != ',') { fix_quality = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, fix_quality);
 
-		if (bufptr && *(++bufptr) != ',') { num_of_sv = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, num_of_sv);
 
-		if (bufptr && *(++bufptr) != ',') { hdop = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, hdop);
 
-		if (bufptr && *(++bufptr) != ',') { alt = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, alt);
 
 		if (ns == 'S') {
 			lat = -lat;
@@ -240,9 +240,8 @@ int GPSDriverAshtech::handleMessage(int len)
 		}
 
 		/* convert from degrees, minutes and seconds to degrees * 1e7 */
-		_gps_position->latitude_deg = static_cast<int>(lat * 0.01) + (lat * 0.01 - static_cast<int>(lat * 0.01)) * 100.0 / 60.0;
-		_gps_position->longitude_deg = static_cast<int>(lon * 0.01) + (lon * 0.01 - static_cast<int>
-					       (lon * 0.01)) * 100.0 / 60.0;
+		_gps_position->latitude_deg = nmeaToDegrees(lat);
+		_gps_position->longitude_deg = nmeaToDegrees(lon);
 		_gps_position->altitude_msl_m = alt;
 		_rate_count_lat_lon++;
 
@@ -285,8 +284,7 @@ int GPSDriverAshtech::handleMessage(int len)
 
 		float heading = 0.f;
 
-		if (bufptr && *(++bufptr) != ',') {
-			heading = strtof(bufptr, &endp); bufptr = endp;
+		if (nmeaNextField(bufptr, heading)) {
 
 			ASH_DEBUG("heading update: %.3f", (double)heading);
 
@@ -349,11 +347,11 @@ int GPSDriverAshtech::handleMessage(int len)
 		ASH_UNUSED(pdop);
 		ASH_UNUSED(tdop);
 
-		if (bufptr && *(++bufptr) != ',') { fix_quality = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, fix_quality);
 
-		if (bufptr && *(++bufptr) != ',') { num_of_sv = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, num_of_sv);
 
-		if (bufptr && *(++bufptr) != ',') { ashtech_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ashtech_time);
 
 		if (bufptr && *(++bufptr) != ',') {
 			/*
@@ -367,7 +365,7 @@ int GPSDriverAshtech::handleMessage(int len)
 			bufptr = endp;
 		}
 
-		if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+		nmeaNextField(bufptr, ns);
 
 		if (bufptr && *(++bufptr) != ',') {
 			lon = strtod(bufptr, &endp);
@@ -377,7 +375,7 @@ int GPSDriverAshtech::handleMessage(int len)
 			bufptr = endp;
 		}
 
-		if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++); }
+		nmeaNextField(bufptr, ew);
 
 		if (bufptr && *(++bufptr) != ',') {
 			alt = strtod(bufptr, &endp);
@@ -387,21 +385,21 @@ int GPSDriverAshtech::handleMessage(int len)
 			bufptr = endp;
 		}
 
-		if (bufptr && *(++bufptr) != ',') { age_of_corr = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, age_of_corr);
 
-		if (bufptr && *(++bufptr) != ',') { track_true = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, track_true);
 
-		if (bufptr && *(++bufptr) != ',') { ground_speed = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ground_speed);
 
-		if (bufptr && *(++bufptr) != ',') { vertic_vel = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, vertic_vel);
 
-		if (bufptr && *(++bufptr) != ',') { pdop = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, pdop);
 
-		if (bufptr && *(++bufptr) != ',') { hdop = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, hdop);
 
-		if (bufptr && *(++bufptr) != ',') { vdop = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, vdop);
 
-		if (bufptr && *(++bufptr) != ',') { tdop = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, tdop);
 
 		if (ns == 'S') {
 			lat = -lat;
@@ -411,9 +409,8 @@ int GPSDriverAshtech::handleMessage(int len)
 			lon = -lon;
 		}
 
-		_gps_position->latitude_deg = static_cast<int>(lat * 0.01) + (lat * 0.01 - static_cast<int>(lat * 0.01)) * 100.0 / 60.0;
-		_gps_position->longitude_deg = static_cast<int>(lon * 0.01) + (lon * 0.01 - static_cast<int>
-					       (lon * 0.01)) * 100.0 / 60.0;
+		_gps_position->latitude_deg = nmeaToDegrees(lat);
+		_gps_position->longitude_deg = nmeaToDegrees(lon);
 		_gps_position->altitude_msl_m = alt;
 		_gps_position->hdop = static_cast<float>(hdop);
 		_gps_position->vdop = static_cast<float>(vdop);
@@ -496,21 +493,21 @@ int GPSDriverAshtech::handleMessage(int len)
 		ASH_UNUSED(deg_from_north);
 		ASH_UNUSED(rms_err);
 
-		if (bufptr && *(++bufptr) != ',') { ashtech_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ashtech_time);
 
-		if (bufptr && *(++bufptr) != ',') { rms_err = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, rms_err);
 
-		if (bufptr && *(++bufptr) != ',') { maj_err = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, maj_err);
 
-		if (bufptr && *(++bufptr) != ',') { min_err = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, min_err);
 
-		if (bufptr && *(++bufptr) != ',') { deg_from_north = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, deg_from_north);
 
-		if (bufptr && *(++bufptr) != ',') { lat_err = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lat_err);
 
-		if (bufptr && *(++bufptr) != ',') { lon_err = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lon_err);
 
-		if (bufptr && *(++bufptr) != ',') { alt_err = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, alt_err);
 
 		_gps_position->eph = sqrtf(static_cast<float>(lat_err) * static_cast<float>(lat_err)
 					   + static_cast<float>(lon_err) * static_cast<float>(lon_err));
@@ -563,11 +560,11 @@ int GPSDriverAshtech::handleMessage(int len)
 
 		memset(sat, 0, sizeof(sat));
 
-		if (bufptr && *(++bufptr) != ',') { all_msg_num = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, all_msg_num);
 
-		if (bufptr && *(++bufptr) != ',') { this_msg_num = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, this_msg_num);
 
-		if (bufptr && *(++bufptr) != ',') { tot_sv_visible = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, tot_sv_visible);
 
 		if ((this_msg_num < 1) || (this_msg_num > all_msg_num)) {
 			return 0;
@@ -597,13 +594,13 @@ int GPSDriverAshtech::handleMessage(int len)
 
 		if (_satellite_info) {
 			for (int y = 0 ; y < end ; y++) {
-				if (bufptr && *(++bufptr) != ',') { sat[y].svid = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].svid);
 
-				if (bufptr && *(++bufptr) != ',') { sat[y].elevation = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].elevation);
 
-				if (bufptr && *(++bufptr) != ',') { sat[y].azimuth = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].azimuth);
 
-				if (bufptr && *(++bufptr) != ',') { sat[y].snr = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].snr);
 
 				_satellite_info->svid[y + (this_msg_num - 1) * 4]      = sat[y].svid;
 				_satellite_info->used[y + (this_msg_num - 1) * 4]      = (sat[y].snr > 0);
@@ -679,22 +676,22 @@ int GPSDriverAshtech::handleMessage(int len)
 
 				if (bufptr) { bufptr = strstr(bufptr + 1, ","); }
 
-				if (bufptr && *(++bufptr) != ',') { lat = strtod(bufptr, &endp); bufptr = endp; }
+				nmeaNextField(bufptr, lat);
 
-				if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+				nmeaNextField(bufptr, ns);
 
-				if (bufptr && *(++bufptr) != ',') { lon = strtod(bufptr, &endp); bufptr = endp; }
+				nmeaNextField(bufptr, lon);
 
-				if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++); }
+				nmeaNextField(bufptr, ew);
 
-				if (bufptr && *(++bufptr) != ',') { alt = strtod(bufptr, &endp); bufptr = endp; }
+				nmeaNextField(bufptr, alt);
 
 				if (ns == 'S') { lat = -lat; }
 
 				if (ew == 'W') { lon = -lon; }
 
-				lat = int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0;
-				lon = int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0;
+				lat = nmeaToDegrees(lat);
+				lon = nmeaToDegrees(lon);
 
 				sendSurveyInStatusUpdate(false, true, lat, lon, alt);
 

--- a/src/ashtech.cpp
+++ b/src/ashtech.cpp
@@ -85,7 +85,6 @@ int GPSDriverAshtech::handleMessage(int len)
 	int ret = 0;
 
 	if ((memcmp(_rx_buffer + 3, "ZDA,", 3) == 0) && (uiCalcComma == 6)) {
-#ifndef NO_MKTIME
 		/*
 		UTC day, month, and year, and local time zone offset
 		An example of the ZDA message string is:
@@ -124,44 +123,16 @@ int GPSDriverAshtech::handleMessage(int len)
 		int ashtech_hour = static_cast<int>(ashtech_time / 10000);
 		int ashtech_minute = static_cast<int>((ashtech_time - ashtech_hour * 10000) / 100);
 		double ashtech_sec = static_cast<double>(ashtech_time - ashtech_hour * 10000 - ashtech_minute * 100);
+		uint64_t usecs = static_cast<uint64_t>((ashtech_sec - static_cast<uint64_t>(ashtech_sec))) * 1000000;
 
-		/*
-		 * convert to unix timestamp
-		 */
-		struct tm timeinfo = {};
+		tm timeinfo{};
 		timeinfo.tm_year = year - 1900;
 		timeinfo.tm_mon = month - 1;
 		timeinfo.tm_mday = day;
 		timeinfo.tm_hour = ashtech_hour;
 		timeinfo.tm_min = ashtech_minute;
 		timeinfo.tm_sec = int(ashtech_sec);
-		timeinfo.tm_isdst = 0;
-
-		time_t epoch = mktime(&timeinfo);
-
-		if (epoch > GPS_EPOCH_SECS) {
-			uint64_t usecs = static_cast<uint64_t>((ashtech_sec - static_cast<uint64_t>(ashtech_sec))) * 1000000;
-
-			// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-			// and control its drift. Since we rely on the HRT for our monotonic
-			// clock, updating it from time to time is safe.
-
-			timespec ts{};
-			ts.tv_sec = epoch;
-			ts.tv_nsec = usecs * 1000;
-
-			setClock(ts);
-
-			_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-			_gps_position->time_utc_usec += usecs;
-
-		} else {
-			_gps_position->time_utc_usec = 0;
-		}
-
-#else
-		_gps_position->time_utc_usec = 0;
-#endif
+		_gps_position->time_utc_usec = timeFromUtc(timeinfo, usecs * 1000);
 
 		_last_timestamp_time = gps_absolute_time();
 	}

--- a/src/femtomes.cpp
+++ b/src/femtomes.cpp
@@ -166,29 +166,28 @@ int GPSDriverFemto::handleMessage(int len)
 
 		if (uiCalcComma == 14) {
 			char *bufptr = (char *)(_femto_msg.data + 6);
-			char *endp = nullptr;
 			double ashtech_time = 0.0, lat = 0.0, lon = 0.0, alt = 0.0;
 			int num_of_sv = 0, fix_quality = 0;
 			double hdop = 99.9;
 			char ns = '?', ew = '?';
 
-			if (bufptr && *(++bufptr) != ',') { ashtech_time = strtod(bufptr, &endp); bufptr = endp; }
+			nmeaNextField(bufptr, ashtech_time);
 
-			if (bufptr && *(++bufptr) != ',') { lat = strtod(bufptr, &endp); bufptr = endp; }
+			nmeaNextField(bufptr, lat);
 
-			if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+			nmeaNextField(bufptr, ns);
 
-			if (bufptr && *(++bufptr) != ',') { lon = strtod(bufptr, &endp); bufptr = endp; }
+			nmeaNextField(bufptr, lon);
 
-			if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++); }
+			nmeaNextField(bufptr, ew);
 
-			if (bufptr && *(++bufptr) != ',') { fix_quality = strtol(bufptr, &endp, 10); bufptr = endp; }
+			nmeaNextField(bufptr, fix_quality);
 
-			if (bufptr && *(++bufptr) != ',') { num_of_sv = strtol(bufptr, &endp, 10); bufptr = endp; }
+			nmeaNextField(bufptr, num_of_sv);
 
-			if (bufptr && *(++bufptr) != ',') { hdop = strtod(bufptr, &endp); bufptr = endp; }
+			nmeaNextField(bufptr, hdop);
 
-			if (bufptr && *(++bufptr) != ',') { alt = strtod(bufptr, &endp); bufptr = endp; }
+			nmeaNextField(bufptr, alt);
 
 			if (ns == 'S') {
 				lat = -lat;
@@ -204,8 +203,8 @@ int GPSDriverFemto::handleMessage(int len)
 			if (!_correction_output_activated && 7 == fix_quality) {
 				_survey_in_start = 0;	/**< finished survey-in */
 
-				lat = (int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0) * 10000000;
-				lon = (int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0) * 10000000;
+				lat = nmeaToDegrees(lat) * 10000000;
+				lon = nmeaToDegrees(lon) * 10000000;
 				alt = alt * 1000;
 
 				sendSurveyInStatusUpdate(false, true, lat, lon, (float)alt);

--- a/src/gps_helper.cpp
+++ b/src/gps_helper.cpp
@@ -33,6 +33,7 @@
 
 #include "gps_helper.h"
 #include <math.h>
+#include <stdlib.h>
 
 #ifndef M_PI
 #define M_PI		3.141592653589793238462643383280
@@ -100,4 +101,49 @@ void GPSHelper::ECEF2lla(double ecef_x, double ecef_y, double ecef_z, double &la
 	latitude *= 180. / M_PI;
 
 	// correction for altitude near poles left out.
+}
+
+bool GPSHelper::nmeaNextField(char *&p, double &value)
+{
+	if (p && *(++p) != ',') {
+		value = strtod(p, &p);
+		return true;
+	}
+
+	return false;
+}
+
+bool GPSHelper::nmeaNextField(char *&p, float &value)
+{
+	if (p && *(++p) != ',') {
+		value = strtof(p, &p);
+		return true;
+	}
+
+	return false;
+}
+
+bool GPSHelper::nmeaNextField(char *&p, int &value)
+{
+	if (p && *(++p) != ',') {
+		value = strtol(p, &p, 10);
+		return true;
+	}
+
+	return false;
+}
+
+bool GPSHelper::nmeaNextField(char *&p, char &value)
+{
+	if (p && *(++p) != ',') {
+		value = *(p++);
+		return true;
+	}
+
+	return false;
+}
+
+double GPSHelper::nmeaToDegrees(double ddmm)
+{
+	return int(ddmm * 0.01) + (ddmm * 0.01 - int(ddmm * 0.01)) * 100.0 / 60.0;
 }

--- a/src/gps_helper.cpp
+++ b/src/gps_helper.cpp
@@ -34,6 +34,7 @@
 #include "gps_helper.h"
 #include <math.h>
 #include <stdlib.h>
+#include <time.h>
 
 #ifndef M_PI
 #define M_PI		3.141592653589793238462643383280
@@ -146,4 +147,27 @@ bool GPSHelper::nmeaNextField(char *&p, char &value)
 double GPSHelper::nmeaToDegrees(double ddmm)
 {
 	return int(ddmm * 0.01) + (ddmm * 0.01 - int(ddmm * 0.01)) * 100.0 / 60.0;
+}
+
+uint64_t GPSHelper::timeFromUtc(tm &utc, int32_t nsec, bool set_clock)
+{
+#ifndef NO_MKTIME
+	const time_t epoch = mktime(&utc);
+
+	if (epoch > GPS_EPOCH_SECS) {
+		if (set_clock) {
+			// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
+			// and control its drift. Since we rely on the HRT for our monotonic
+			// clock, updating it from time to time is safe.
+			timespec ts{};
+			ts.tv_sec = epoch;
+			ts.tv_nsec = nsec;
+			setClock(ts);
+		}
+
+		return static_cast<uint64_t>(epoch) * 1000000ULL + nsec / 1000;
+	}
+
+#endif
+	return 0;
 }

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -337,6 +337,21 @@ protected:
 	 */
 	static void ECEF2lla(double ecef_x, double ecef_y, double ecef_z, double &latitude, double &longitude, float &altitude);
 
+	/**
+	 * Parse the next comma-separated NMEA field. p points at the character before the field (the previous
+	 * separator) and is advanced to the separator after it. An empty field leaves value untouched.
+	 * @return true if the field was non-empty
+	 */
+	static bool nmeaNextField(char *&p, double &value);
+	static bool nmeaNextField(char *&p, float &value);
+	static bool nmeaNextField(char *&p, int &value);
+	static bool nmeaNextField(char *&p, char &value);
+
+	/**
+	 * Convert an NMEA ddmm.mmmm (or dddmm.mmmm) coordinate to decimal degrees
+	 */
+	static double nmeaToDegrees(double ddmm);
+
 	GPSCallbackPtr _callback{nullptr};
 	void *_callback_user{};
 

--- a/src/gps_helper.h
+++ b/src/gps_helper.h
@@ -326,6 +326,16 @@ protected:
 	}
 
 	/**
+	 * Convert a broken-down UTC time to microseconds since the Unix epoch, and set the system clock
+	 * from it when requested. Both only happen if the date is after the GPS epoch.
+	 * @param utc broken-down UTC time (modified by mktime)
+	 * @param nsec sub-second part [ns], may be negative
+	 * @param set_clock also set the system clock
+	 * @return microseconds since the Unix epoch, 0 if the date is implausible or mktime is unavailable
+	 */
+	uint64_t timeFromUtc(tm &utc, int32_t nsec, bool set_clock = true);
+
+	/**
 	 * Convert an ECEF (Earth Centered Earth Fixed) coordinate to LLA WGS84 (Lat, Lon, Alt).
 	 * Ported from: https://stackoverflow.com/a/25428344
 	 * @param ecef_x ECEF X-coordinate [m]

--- a/src/mtk.cpp
+++ b/src/mtk.cpp
@@ -246,7 +246,6 @@ GPSDriverMTK::handleMessage(gps_mtk_packet_t &packet)
 	_gps_position->cog_rad = ((float)packet.heading) * M_DEG_TO_RAD_F * 1e-2f; //from deg *100 to rad
 	_gps_position->satellites_used = packet.satellites;
 
-#ifndef NO_MKTIME
 	/* convert time and date information to unix timestamp */
 	struct tm timeinfo = {};
 	uint32_t timeinfo_conversion_temp;
@@ -263,32 +262,7 @@ GPSDriverMTK::handleMessage(gps_mtk_packet_t &packet)
 	timeinfo.tm_sec = timeinfo_conversion_temp / 1000;
 	timeinfo_conversion_temp -= timeinfo.tm_sec * 1000;
 
-	timeinfo.tm_isdst = 0;
-
-
-	time_t epoch = mktime(&timeinfo);
-
-	if (epoch > GPS_EPOCH_SECS) {
-		// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-		// and control its drift. Since we rely on the HRT for our monotonic
-		// clock, updating it from time to time is safe.
-
-		timespec ts{};
-		ts.tv_sec = epoch;
-		ts.tv_nsec = timeinfo_conversion_temp * 1000000ULL;
-
-		setClock(ts);
-
-		_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-		_gps_position->time_utc_usec += timeinfo_conversion_temp * 1000ULL;
-
-	} else {
-		_gps_position->time_utc_usec = 0;
-	}
-
-#else
-	_gps_position->time_utc_usec = 0;
-#endif
+	_gps_position->time_utc_usec = timeFromUtc(timeinfo, timeinfo_conversion_temp * 1000000);
 
 	_gps_position->timestamp = gps_absolute_time();
 	_gps_position->timestamp_time_relative = 0;

--- a/src/nmea.cpp
+++ b/src/nmea.cpp
@@ -86,8 +86,6 @@ GPSDriverNMEA::~GPSDriverNMEA()
 
 int GPSDriverNMEA::handleMessage(int len)
 {
-	char *endp;
-
 	if (len < 7) {
 		return 0;
 	}
@@ -126,17 +124,17 @@ int GPSDriverNMEA::handleMessage(int len)
 		NMEA_UNUSED(local_time_off_hour);
 		NMEA_UNUSED(local_time_off_min);
 
-		if (bufptr && *(++bufptr) != ',') { utc_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, utc_time);
 
-		if (bufptr && *(++bufptr) != ',') { day = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, day);
 
-		if (bufptr && *(++bufptr) != ',') { month = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, month);
 
-		if (bufptr && *(++bufptr) != ',') { year = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, year);
 
-		if (bufptr && *(++bufptr) != ',') { local_time_off_hour = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, local_time_off_hour);
 
-		if (bufptr && *(++bufptr) != ',') { local_time_off_min = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, local_time_off_min);
 
 		int utc_hour = static_cast<int>(utc_time / 10000);
 		int utc_minute = static_cast<int>((utc_time - utc_hour * 10000) / 100);
@@ -196,19 +194,19 @@ int GPSDriverNMEA::handleMessage(int len)
 		double utc_time = 0.0, lat = 0.0, lon = 0.0;
 		char ns = '?', ew = '?', dvalid = '?', modeind = '?';
 
-		if (bufptr && *(++bufptr) != ',') { lat = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lat);
 
-		if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+		nmeaNextField(bufptr, ns);
 
-		if (bufptr && *(++bufptr) != ',') { lon = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lon);
 
-		if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++); }
+		nmeaNextField(bufptr, ew);
 
-		if (bufptr && *(++bufptr) != ',') { utc_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, utc_time);
 
-		if (bufptr && *(++bufptr) != ',') { dvalid = *(bufptr++); }
+		nmeaNextField(bufptr, dvalid);
 
-		if (bufptr && *(++bufptr) != ',') { modeind = *(bufptr++); }
+		nmeaNextField(bufptr, modeind);
 
 		if (ns == 'S') {
 			lat = -lat;
@@ -221,8 +219,8 @@ int GPSDriverNMEA::handleMessage(int len)
 
 		/* only update the values if they are valid */
 		if (dvalid == 'A' && modeind == 'A') {
-			_gps_position->longitude_deg = int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0;
-			_gps_position->latitude_deg = int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0;
+			_gps_position->longitude_deg = nmeaToDegrees(lon);
+			_gps_position->latitude_deg = nmeaToDegrees(lat);
 
 			if (!_POS_received && (_last_POS_timeUTC < utc_time)) {
 				_last_POS_timeUTC = utc_time;
@@ -278,31 +276,31 @@ int GPSDriverNMEA::handleMessage(int len)
 
 		NMEA_UNUSED(dgps_age);
 
-		if (bufptr && *(++bufptr) != ',') { utc_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, utc_time);
 
-		if (bufptr && *(++bufptr) != ',') { lat = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lat);
 
-		if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+		nmeaNextField(bufptr, ns);
 
-		if (bufptr && *(++bufptr) != ',') { lon = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lon);
 
-		if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++); }
+		nmeaNextField(bufptr, ew);
 
-		if (bufptr && *(++bufptr) != ',') { fix_quality = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, fix_quality);
 
-		if (bufptr && *(++bufptr) != ',') { num_of_sv = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, num_of_sv);
 
-		if (bufptr && *(++bufptr) != ',') { hdop = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, hdop);
 
-		if (bufptr && *(++bufptr) != ',') { alt = strtof(bufptr, &endp); bufptr = endp; }
-
-		while (*(++bufptr) != ',') {} //skip M
-
-		if (bufptr && *(++bufptr) != ',') { geoid_h = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, alt);
 
 		while (*(++bufptr) != ',') {} //skip M
 
-		if (bufptr && *(++bufptr) != ',') { dgps_age = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, geoid_h);
+
+		while (*(++bufptr) != ',') {} //skip M
+
+		nmeaNextField(bufptr, dgps_age);
 
 		if (ns == 'S') {
 			lat = -lat;
@@ -313,8 +311,8 @@ int GPSDriverNMEA::handleMessage(int len)
 		}
 
 		/* convert from degrees, minutes and seconds to degrees */
-		_gps_position->longitude_deg = int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0;
-		_gps_position->latitude_deg = int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0;
+		_gps_position->longitude_deg = nmeaToDegrees(lon);
+		_gps_position->latitude_deg = nmeaToDegrees(lat);
 		_gps_position->hdop = hdop;
 		_gps_position->altitude_msl_m = (double)alt;
 		_gps_position->altitude_ellipsoid_m = (double)(alt + geoid_h);
@@ -361,8 +359,7 @@ int GPSDriverNMEA::handleMessage(int len)
 
 		float heading_deg = 0.f;
 
-		if (bufptr && *(++bufptr) != ',') {
-			heading_deg = strtof(bufptr, &endp); bufptr = endp;
+		if (nmeaNextField(bufptr, heading_deg)) {
 			handleHeading(heading_deg, NAN);
 		}
 
@@ -410,15 +407,15 @@ int GPSDriverNMEA::handleMessage(int len)
 		int i = 0;
 		NMEA_UNUSED(pos_Mode);
 
-		if (bufptr && *(++bufptr) != ',') { utc_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, utc_time);
 
-		if (bufptr && *(++bufptr) != ',') { lat = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lat);
 
-		if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+		nmeaNextField(bufptr, ns);
 
-		if (bufptr && *(++bufptr) != ',') { lon = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lon);
 
-		if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++);}
+		nmeaNextField(bufptr, ew);
 
 		/* as more GPS systems are added this string can grow, so only parse out the first X, but keep going until we hit the end of field */
 		do {
@@ -426,13 +423,13 @@ int GPSDriverNMEA::handleMessage(int len)
 
 		} while (*(++bufptr) != ',');
 
-		if (bufptr && *(++bufptr) != ',') { num_of_sv = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, num_of_sv);
 
-		if (bufptr && *(++bufptr) != ',') { hdop = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, hdop);
 
-		if (bufptr && *(++bufptr) != ',') { alt = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, alt);
 
-		if (bufptr && *(++bufptr) != ',') { geoid_h = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, geoid_h);
 
 		if (ns == 'S') {
 			lat = -lat;
@@ -443,8 +440,8 @@ int GPSDriverNMEA::handleMessage(int len)
 		}
 
 		/* convert from degrees, minutes and seconds to degrees */
-		_gps_position->latitude_deg = int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0;
-		_gps_position->longitude_deg = int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0;
+		_gps_position->latitude_deg = nmeaToDegrees(lat);
+		_gps_position->longitude_deg = nmeaToDegrees(lon);
 		_gps_position->hdop = hdop;
 		_gps_position->altitude_msl_m = (double)alt;
 		_gps_position->altitude_ellipsoid_m = (double)(alt + geoid_h);
@@ -494,25 +491,25 @@ int GPSDriverNMEA::handleMessage(int len)
 		char ns = '?', ew = '?';
 		NMEA_UNUSED(Mag_var);
 
-		if (bufptr && *(++bufptr) != ',') { utc_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, utc_time);
 
-		if (bufptr && *(++bufptr) != ',') { Status = *(bufptr++); }
+		nmeaNextField(bufptr, Status);
 
-		if (bufptr && *(++bufptr) != ',') { lat = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lat);
 
-		if (bufptr && *(++bufptr) != ',') { ns = *(bufptr++); }
+		nmeaNextField(bufptr, ns);
 
-		if (bufptr && *(++bufptr) != ',') { lon = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lon);
 
-		if (bufptr && *(++bufptr) != ',') { ew = *(bufptr++); }
+		nmeaNextField(bufptr, ew);
 
-		if (bufptr && *(++bufptr) != ',') { ground_speed_K = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ground_speed_K);
 
-		if (bufptr && *(++bufptr) != ',') { track_true = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, track_true);
 
-		if (bufptr && *(++bufptr) != ',') { nmea_date = static_cast<int>(strtol(bufptr, &endp, 10)); bufptr = endp; }
+		nmeaNextField(bufptr, nmea_date);
 
-		if (bufptr && *(++bufptr) != ',') { Mag_var = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, Mag_var);
 
 		if (ns == 'S') {
 			lat = -lat;
@@ -543,8 +540,8 @@ int GPSDriverNMEA::handleMessage(int len)
 			// We ignore RMC position for Unicore, because we have GGA configured at the rate we want.
 
 			/* convert from degrees, minutes and seconds to degrees */
-			_gps_position->latitude_deg = int(lat * 0.01) + (lat * 0.01 - int(lat * 0.01)) * 100.0 / 60.0;
-			_gps_position->longitude_deg = int(lon * 0.01) + (lon * 0.01 - int(lon * 0.01)) * 100.0 / 60.0;
+			_gps_position->latitude_deg = nmeaToDegrees(lat);
+			_gps_position->longitude_deg = nmeaToDegrees(lon);
 
 			if (!_POS_received && (_last_POS_timeUTC < utc_time)) {
 				_gps_position->timestamp = gps_absolute_time();
@@ -656,21 +653,21 @@ int GPSDriverNMEA::handleMessage(int len)
 		NMEA_UNUSED(deg_from_north);
 		NMEA_UNUSED(rms_err);
 
-		if (bufptr && *(++bufptr) != ',') { utc_time = strtod(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, utc_time);
 
-		if (bufptr && *(++bufptr) != ',') { rms_err = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, rms_err);
 
-		if (bufptr && *(++bufptr) != ',') { maj_err = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, maj_err);
 
-		if (bufptr && *(++bufptr) != ',') { min_err = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, min_err);
 
-		if (bufptr && *(++bufptr) != ',') { deg_from_north = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, deg_from_north);
 
-		if (bufptr && *(++bufptr) != ',') { lat_err = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lat_err);
 
-		if (bufptr && *(++bufptr) != ',') { lon_err = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, lon_err);
 
-		if (bufptr && *(++bufptr) != ',') { alt_err = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, alt_err);
 
 		_gps_position->eph = sqrtf(static_cast<float>(lat_err) * static_cast<float>(lat_err)
 					   + static_cast<float>(lon_err) * static_cast<float>(lon_err));
@@ -708,19 +705,19 @@ int GPSDriverNMEA::handleMessage(int len)
 		NMEA_UNUSED(sat_id);
 		NMEA_UNUSED(pdop);
 
-		if (bufptr && *(++bufptr) != ',') { M_pos = *(bufptr++); }
+		nmeaNextField(bufptr, M_pos);
 
-		if (bufptr && *(++bufptr) != ',') { fix_mode = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, fix_mode);
 
 		for (int y = 0; y < 12; y++) {
-			if (bufptr && *(++bufptr) != ',') {sat_id[y] = strtol(bufptr, &endp, 10); bufptr = endp; }
+			nmeaNextField(bufptr, sat_id[y]);
 		}
 
-		if (bufptr && *(++bufptr) != ',') { pdop = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, pdop);
 
-		if (bufptr && *(++bufptr) != ',') { hdop = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, hdop);
 
-		if (bufptr && *(++bufptr) != ',') { vdop = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, vdop);
 
 		if (fix_mode <= 1) {
 			_gps_position->fix_type = 0;
@@ -763,11 +760,11 @@ int GPSDriverNMEA::handleMessage(int len)
 			int snr;
 		} sat[4] {};
 
-		if (bufptr && *(++bufptr) != ',') { all_page_num = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, all_page_num);
 
-		if (bufptr && *(++bufptr) != ',') { this_page_num = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, this_page_num);
 
-		if (bufptr && *(++bufptr) != ',') { tot_sv_visible = strtol(bufptr, &endp, 10); bufptr = endp; }
+		nmeaNextField(bufptr, tot_sv_visible);
 
 		if ((this_page_num < 1) || (this_page_num > all_page_num)) {
 			return 0;
@@ -815,13 +812,13 @@ int GPSDriverNMEA::handleMessage(int len)
 
 		if (_satellite_info) {
 			for (int y = 0 ; y < end ; y++) {
-				if (bufptr && *(++bufptr) != ',') { sat[y].svid = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].svid);
 
-				if (bufptr && *(++bufptr) != ',') { sat[y].elevation = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].elevation);
 
-				if (bufptr && *(++bufptr) != ',') { sat[y].azimuth = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].azimuth);
 
-				if (bufptr && *(++bufptr) != ',') { sat[y].snr = strtol(bufptr, &endp, 10); bufptr = endp; }
+				nmeaNextField(bufptr, sat[y].snr);
 
 				_satellite_info->svid[y + (this_page_num - 1) * 4]      = sat[y].svid;
 				_satellite_info->used[y + (this_page_num - 1) * 4]      = (sat[y].snr > 0);
@@ -865,21 +862,21 @@ int GPSDriverNMEA::handleMessage(int len)
 		NMEA_UNUSED(ground_speed_K);
 		NMEA_UNUSED(K);
 
-		if (bufptr && *(++bufptr) != ',') {track_true = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, track_true);
 
-		if (bufptr && *(++bufptr) != ',') { T = *(bufptr++); }
+		nmeaNextField(bufptr, T);
 
-		if (bufptr && *(++bufptr) != ',') {track_mag = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, track_mag);
 
-		if (bufptr && *(++bufptr) != ',') { M = *(bufptr++); }
+		nmeaNextField(bufptr, M);
 
-		if (bufptr && *(++bufptr) != ',') { ground_speed = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ground_speed);
 
-		if (bufptr && *(++bufptr) != ',') { N = *(bufptr++); }
+		nmeaNextField(bufptr, N);
 
-		if (bufptr && *(++bufptr) != ',') { ground_speed_K = strtof(bufptr, &endp); bufptr = endp; }
+		nmeaNextField(bufptr, ground_speed_K);
 
-		if (bufptr && *(++bufptr) != ',') { K = *(bufptr++); }
+		nmeaNextField(bufptr, K);
 
 		float track_rad = track_true * M_PI_F / 180.0f; // rad in range [0, 2pi]
 

--- a/src/nmea.cpp
+++ b/src/nmea.cpp
@@ -84,6 +84,28 @@ GPSDriverNMEA::~GPSDriverNMEA()
  * http://www.trimble.com/OEM_ReceiverHelp/V4.44/en/NMEA-0183messages_MessageOverview.html
  */
 
+void GPSDriverNMEA::setTimeUtc(int year, int month, int day, double utc_hhmmss)
+{
+	int utc_hour = static_cast<int>(utc_hhmmss / 10000);
+	int utc_minute = static_cast<int>((utc_hhmmss - utc_hour * 10000) / 100);
+	double utc_sec = static_cast<double>(utc_hhmmss - utc_hour * 10000 - utc_minute * 100);
+	uint64_t usecs = static_cast<uint64_t>((utc_sec - static_cast<uint64_t>(utc_sec)) * 1000000);
+
+	tm timeinfo{};
+	timeinfo.tm_year = year - 1900;
+	timeinfo.tm_mon = month - 1;
+	timeinfo.tm_mday = day;
+	timeinfo.tm_hour = utc_hour;
+	timeinfo.tm_min = utc_minute;
+	timeinfo.tm_sec = int(utc_sec);
+
+	_gps_position->time_utc_usec = timeFromUtc(timeinfo, usecs * 1000, !_clock_set);
+
+	if (_gps_position->time_utc_usec != 0) {
+		_clock_set = true;
+	}
+}
+
 int GPSDriverNMEA::handleMessage(int len)
 {
 	if (len < 7) {
@@ -100,7 +122,6 @@ int GPSDriverNMEA::handleMessage(int len)
 	int ret = 0;
 
 	if ((memcmp(_rx_buffer + 3, "ZDA,", 4) == 0) && (fieldCount == 6)) {
-#ifndef NO_MKTIME
 		/*
 		UTC day, month, and year, and local time zone offset
 		An example of the ZDA message string is:
@@ -136,51 +157,7 @@ int GPSDriverNMEA::handleMessage(int len)
 
 		nmeaNextField(bufptr, local_time_off_min);
 
-		int utc_hour = static_cast<int>(utc_time / 10000);
-		int utc_minute = static_cast<int>((utc_time - utc_hour * 10000) / 100);
-		double utc_sec = static_cast<double>(utc_time - utc_hour * 10000 - utc_minute * 100);
-
-
-		/*
-		* convert to unix timestamp
-		*/
-		struct tm timeinfo = {};
-		timeinfo.tm_year = year - 1900;
-		timeinfo.tm_mon = month - 1;
-		timeinfo.tm_mday = day;
-		timeinfo.tm_hour = utc_hour;
-		timeinfo.tm_min = utc_minute;
-		timeinfo.tm_sec = int(utc_sec);
-		timeinfo.tm_isdst = 0;
-
-
-		time_t epoch = mktime(&timeinfo);
-
-		if (epoch > GPS_EPOCH_SECS) {
-			uint64_t usecs = static_cast<uint64_t>((utc_sec - static_cast<uint64_t>(utc_sec)) * 1000000);
-
-			// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-			// and control its drift. Since we rely on the HRT for our monotonic
-			// clock, updating it from time to time is safe.
-
-			if (!_clock_set) {
-				timespec ts{};
-				ts.tv_sec = epoch;
-				ts.tv_nsec = usecs * 1000;
-				setClock(ts);
-				_clock_set = true;
-			}
-
-			_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-			_gps_position->time_utc_usec += usecs;
-
-		} else {
-			_gps_position->time_utc_usec = 0;
-		}
-
-#else
-		_gps_position->time_utc_usec = 0;
-#endif
+		setTimeUtc(year, month, day, utc_time);
 		_last_timestamp_time = gps_absolute_time();
 		_TIME_received = true;
 
@@ -563,54 +540,10 @@ int GPSDriverNMEA::handleMessage(int len)
 			}
 		}
 
-#ifndef NO_MKTIME
-		int utc_hour = static_cast<int>(utc_time / 10000);
-		int utc_minute = static_cast<int>((utc_time - utc_hour * 10000) / 100);
-		double utc_sec = static_cast<double>(utc_time - utc_hour * 10000 - utc_minute * 100);
 		int nmea_day = static_cast<int>(nmea_date / 10000);
 		int nmea_mth = static_cast<int>((nmea_date - nmea_day * 10000) / 100);
 		int nmea_year = static_cast<int>(nmea_date - nmea_day * 10000 - nmea_mth * 100);
-		/*
-		 * convert to unix timestamp
-		 */
-		struct tm timeinfo = {};
-		timeinfo.tm_year = nmea_year + 100;
-		timeinfo.tm_mon = nmea_mth - 1;
-		timeinfo.tm_mday = nmea_day;
-		timeinfo.tm_hour = utc_hour;
-		timeinfo.tm_min = utc_minute;
-		timeinfo.tm_sec = int(utc_sec);
-		timeinfo.tm_isdst = 0;
-
-		time_t epoch = mktime(&timeinfo);
-
-		if (epoch > GPS_EPOCH_SECS) {
-			uint64_t usecs = static_cast<uint64_t>((utc_sec - static_cast<uint64_t>(utc_sec)) * 1000000);
-
-			// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-			// and control its drift. Since we rely on the HRT for our monotonic
-			// clock, updating it from time to time is safe.
-			if (!_clock_set) {
-				timespec ts{};
-				ts.tv_sec = epoch;
-				ts.tv_nsec = usecs * 1000;
-
-				setClock(ts);
-				_clock_set = true;
-			}
-
-			_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-			_gps_position->time_utc_usec += usecs;
-
-		} else {
-			_gps_position->time_utc_usec = 0;
-		}
-
-#else
-		NMEA_UNUSED(utc_time);
-		NMEA_UNUSED(nmea_date);
-		_gps_position->time_utc_usec = 0;
-#endif
+		setTimeUtc(nmea_year + 2000, nmea_mth, nmea_day, utc_time);
 
 		_last_timestamp_time = gps_absolute_time();
 		_TIME_received = true;

--- a/src/nmea.h
+++ b/src/nmea.h
@@ -86,6 +86,9 @@ private:
 	int handleMessage(int len);
 	int parseChar(uint8_t b);
 
+	/** Set time_utc_usec from a UTC date and an NMEA hhmmss.ss time, and the system clock the first time */
+	void setTimeUtc(int year, int month, int day, double utc_hhmmss);
+
 	int32_t read_int();
 	double read_float();
 	char read_char();

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2296,35 +2296,30 @@ GPSDriverUBX::payloadRxAddMonVer(const uint8_t b)
 			UBX_DEBUG("VER sw  \"%30s\"", _buf.payload_rx_mon_ver_part1.swVersion);
 
 			// Device detection (See https://forum.u-blox.com/index.php/9432/need-help-decoding-ubx-mon-ver-hardware-string)
-			if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "00040005",
-				    sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
-				_board = Board::u_blox5;
+			static constexpr struct {
+				char hw_version[9];
+				Board board;
+			} known_boards[] = {
+				{"00040005", Board::u_blox5},
+				{"00040007", Board::u_blox6},
+				{"00070000", Board::u_blox7},
+				{"00080000", Board::u_blox8},
+				{"00190000", Board::u_blox9},
+				{"000A0000", Board::u_blox10},
+				{"000B0000", Board::u_blox_X20},
+			};
+			bool known = false;
 
-			} else if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "00040007",
-					   sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
-				_board = Board::u_blox6;
+			for (const auto &known_board : known_boards) {
+				if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, known_board.hw_version,
+					    sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
+					_board = known_board.board;
+					known = true;
+					break;
+				}
+			}
 
-			} else if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "00070000",
-					   sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
-				_board = Board::u_blox7;
-
-			} else if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "00080000",
-					   sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
-				_board = Board::u_blox8;
-
-			} else if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "00190000",
-					   sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
-				_board = Board::u_blox9;
-
-			} else if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "000A0000",
-					   sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
-				_board = Board::u_blox10;
-
-			} else if (strncmp((const char *)_buf.payload_rx_mon_ver_part1.hwVersion, "000B0000",
-					   sizeof(_buf.payload_rx_mon_ver_part1.hwVersion)) == 0) {
-				_board = Board::u_blox_X20;
-
-			} else {
+			if (!known) {
 				UBX_WARN("unknown board hw: %s", _buf.payload_rx_mon_ver_part1.hwVersion);
 			}
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -68,6 +68,30 @@
 #define UBX_WARN(...)         {GPS_WARN(__VA_ARGS__);}
 #define UBX_DEBUG(...)        {/*GPS_WARN(__VA_ARGS__);*/}
 
+// RTCM3 message sets for a base: the station/bias messages plus GPS, GLONASS, Galileo and BeiDou
+// observations as MSM4 or MSM7 (1074/1084/1094/1124 vs 1077/1087/1097/1127)
+static constexpr uint32_t RTCM_BASE_MSGOUT_I2C[] = {
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C,
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C,
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C
+};
+static constexpr uint32_t RTCM_MSM4_UART1[] = {
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART1, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART1,
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART1, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART1
+};
+static constexpr uint32_t RTCM_MSM7_UART1[] = {
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1,
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1
+};
+static constexpr uint32_t RTCM_MSM4_UART2[] = {
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART2, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART2,
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART2, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART2
+};
+static constexpr uint32_t RTCM_MSM7_UART2[] = {
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2,
+	UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2
+};
+
 GPSDriverUBX::GPSDriverUBX(Interface gpsInterface, GPSCallbackPtr callback, void *callback_user,
 			   sensor_gps_s *gps_position, satellite_info_s *satellite_info, Settings settings) :
 	GPSBaseStationSupport(callback, callback_user),
@@ -160,15 +184,17 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 			}
 
 			// try CFG-VALSET: if we get an ACK we know we can use protocol version 27+
+			static constexpr CfgValsetItem uart1_ubx[] = {
+				{UBX_CFG_KEY_CFG_UART1_STOPBITS, 1},
+				{UBX_CFG_KEY_CFG_UART1_DATABITS, 0},
+				{UBX_CFG_KEY_CFG_UART1_PARITY, 0},
+				{UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1},
+				{UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0},
+				{UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1},
+				{UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA, 0},
+			};
 			initCfgValset();
-			// UART1
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_STOPBITS, 1);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_DATABITS, 0);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_PARITY, 0);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA, 0);
+			cfgValset(uart1_ubx);
 			// TODO: are we ever connected to UART2?
 
 			// Note: USB protocol settings are handled later in the configureDevice function.
@@ -673,11 +699,11 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	// Disable odometer. Separate, non-fatal VALSET: CFG-ODO-* was removed on the
 	// F20 platform (ZED-X20P HPG 2.10+), so a NAK here must not abort config.
+	static constexpr uint32_t odo_keys[] = {
+		UBX_CFG_KEY_ODO_USE_ODO, UBX_CFG_KEY_ODO_USE_COG, UBX_CFG_KEY_ODO_OUTLPVEL, UBX_CFG_KEY_ODO_OUTLPCOG
+	};
 	initCfgValset();
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_COG, 0);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPVEL, 0);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPCOG, 0);
+	cfgValset(odo_keys, 0);
 
 	if (sendCfgValset()) {
 		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
@@ -963,9 +989,10 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	// (u-center, or another firmware such as ArduPilot, which writes CFG-VALSET to the
 	// BBR/FLASH layers). Clearing them here rather than waiting for payloadRxInit() to
 	// notice them avoids wasting UART bandwidth on every boot.
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C, 0);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C, 0);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C, 0);
+	static constexpr uint32_t unused_msgout[] = {
+		UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C, UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C, UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C
+	};
+	cfgValsetPort(unused_msgout, 0);
 
 	if (!sendCfgValset()) {
 		return -1;
@@ -1050,10 +1077,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 		// Configure MSM7 message outputs on UART1
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1); // GLONASS bias
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 1); // GPS MSM7
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 1); // GLONASS MSM7
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 1); // Galileo MSM7
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 1); // BeiDou MSM7
+		cfgValset(RTCM_MSM7_UART1, 1);
 
 		if (!sendCfgValset()) {
 			return -1;
@@ -1065,18 +1089,21 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_mode == UBXMode::RoverWithStaticBaseUART2 || _mode == UBXMode::RoverWithMovingBaseUART2) {
 		UBX_DEBUG("Configuring UART2 for rover");
+		// UBX only on UART1, RTCM input on UART2
+		static constexpr CfgValsetItem rover_uart2[] = {
+			{UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1},
+			{UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0},
+			{UBX_CFG_KEY_CFG_UART2_STOPBITS, 1},
+			{UBX_CFG_KEY_CFG_UART2_DATABITS, 0},
+			{UBX_CFG_KEY_CFG_UART2_PARITY, 0},
+			{UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0},
+			{UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1},
+			{UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0},
+			{UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0},
+			{UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0},
+		};
 		initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0);
-		// enable RTCM input on uart2 + set baudrate
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0);
+		cfgValset(rover_uart2);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
 
 		if (!sendCfgValset()) {
@@ -1092,43 +1119,24 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_mode == UBXMode::MovingBaseUART2) {
 		UBX_DEBUG("Configuring UART2 for moving base");
-		// enable RTCM output on uart2 + set baudrate
+		// RTCM output on UART2
+		static constexpr CfgValsetItem moving_base_uart2[] = {
+			{UBX_CFG_KEY_CFG_UART2_STOPBITS, 1},
+			{UBX_CFG_KEY_CFG_UART2_DATABITS, 0},
+			{UBX_CFG_KEY_CFG_UART2_PARITY, 0},
+			{UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0},
+			{UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1},
+			{UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0},
+			{UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0},
+			{UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 1},
+			{UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART2, 1}, // GLONASS bias
+		};
 		initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 1);
+		cfgValset(moving_base_uart2);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART2, 1); // GLONASS bias
-
-		if (_ppk_output) {
-			UBX_DEBUG("Enabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, 1); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2, 1); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, 1); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2, 1); // BeiDou MSM7
-			UBX_DEBUG("Disabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART2, 0); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART2, 0); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART2, 0); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART2, 0); // BeiDou MSM4
-
-		} else {
-			UBX_DEBUG("Enabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART2, 1); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART2, 1); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART2, 1); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART2, 1); // BeiDou MSM4
-			UBX_DEBUG("Disabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, 0); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2, 0); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, 0); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2, 0); // BeiDou MSM7
-		}
+		// MSM7 for PPK, MSM4 otherwise, never both
+		cfgValset(RTCM_MSM7_UART2, _ppk_output ? 1 : 0);
+		cfgValset(RTCM_MSM4_UART2, _ppk_output ? 0 : 1);
 
 		// 4072.0 marks the base as moving, without it the rover solves against it as a
 		// static base and never reports a heading. The F9P-15B doesn't support 4072.
@@ -1149,13 +1157,16 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_mode == UBXMode::RoverWithMovingBaseUART1) {
 		UBX_DEBUG("Configuring UART1 for rover");
-		// heading output period 1 second
+		// RTCM input on UART1
+		static constexpr CfgValsetItem rover_uart1[] = {
+			{UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1},
+			{UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1},
+			{UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0},
+			{UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1},
+			{UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0},
+		};
 		initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0);
+		cfgValset(rover_uart1);
 
 		if (!sendCfgValset()) {
 			return -1;
@@ -1167,39 +1178,20 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_mode == UBXMode::MovingBaseUART1) {
 		UBX_DEBUG("Configuring UART1 for moving base");
-		// enable RTCM output on uart1
+		// RTCM output on UART1
+		static constexpr CfgValsetItem moving_base_uart1[] = {
+			{UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1},
+			{UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1},
+			{UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0},
+			{UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1},
+			{UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1},
+			{UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1}, // GLONASS bias
+		};
 		initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1); // GLONASS bias
-
-		if (_ppk_output) {
-			UBX_DEBUG("Enabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 1); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 1); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 1); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 1); // BeiDou MSM7
-			UBX_DEBUG("Disabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART1, 0); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART1, 0); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART1, 0); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART1, 0); // BeiDou MSM4
-
-		} else {
-			UBX_DEBUG("Enabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART1, 1); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART1, 1); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART1, 1); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART1, 1); // BeiDou MSM4
-			UBX_DEBUG("Disabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 0); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 0); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 0); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 0); // BeiDou MSM7
-		}
+		cfgValset(moving_base_uart1);
+		// MSM7 for PPK, MSM4 otherwise, never both
+		cfgValset(RTCM_MSM7_UART1, _ppk_output ? 1 : 0);
+		cfgValset(RTCM_MSM4_UART1, _ppk_output ? 0 : 1);
 
 		// 4072.0 marks the base as moving, without it the rover solves against it as a
 		// static base and never reports a heading. The F9P-15B doesn't support 4072.
@@ -1218,16 +1210,20 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_mode == UBXMode::GroundControlStation) {
 		UBX_DEBUG("Configuring UART2 for Ground Control Station");
+		// NMEA output only on UART2
+		static constexpr CfgValsetItem gcs_uart2[] = {
+			{UBX_CFG_KEY_CFG_UART2_STOPBITS, 1},
+			{UBX_CFG_KEY_CFG_UART2_DATABITS, 0},
+			{UBX_CFG_KEY_CFG_UART2_PARITY, 0},
+			{UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0},
+			{UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0},
+			{UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0},
+			{UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 1},
+			{UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0},
+			{UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0},
+		};
 		initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 1);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0);
+		cfgValset(gcs_uart2);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
 
 		if (!sendCfgValset()) {
@@ -1257,18 +1253,21 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 				(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 			}
 
+			// Input stays open so u-center can poll MON-VER and drive the configuration view
+			static constexpr CfgValsetItem ucenter_uart2[] = {
+				{UBX_CFG_KEY_CFG_UART2_STOPBITS, 1},
+				{UBX_CFG_KEY_CFG_UART2_DATABITS, 0},
+				{UBX_CFG_KEY_CFG_UART2_PARITY, 0},
+				{UBX_CFG_KEY_CFG_UART2INPROT_UBX, 1},
+				{UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0},
+				{UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0},
+				{UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 1},
+				{UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 0},
+				{UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0},
+			};
 			initCfgValset();
 			cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
-			// Input stays open so u-center can poll MON-VER and drive the configuration view
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 1);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 1);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 0);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0);
+			cfgValset(ucenter_uart2);
 
 			if (sendCfgValset()) {
 				if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
@@ -1278,11 +1277,12 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 			// Message rates are per port, so the set enabled for the driver's own port leaves UART2
 			// silent. u-center shows nothing at all without these.
+			static constexpr uint32_t ucenter_msgout[] = {
+				UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C,
+				UBX_CFG_KEY_MSGOUT_UBX_NAV_STATUS_I2C, UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C
+			};
 			initCfgValset();
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1);
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1);
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_STATUS_I2C, 1);
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1);
+			cfgValsetUart2(ucenter_msgout, 1);
 			// NAV-SAT is 12 bytes per satellite against ~250 for all of the above together, so it
 			// gets the same decimation the driver uses for itself rather than setting the link speed
 			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, 10);
@@ -1393,6 +1393,50 @@ bool GPSDriverUBX::cfgValsetUart2(uint32_t key_id, uint8_t value)
 	return cfgValset<uint8_t>(key_id + 2, value);
 }
 
+bool GPSDriverUBX::cfgValsetItems(const CfgValsetItem *items, size_t count)
+{
+	for (size_t i = 0; i < count; i++) {
+		if (!cfgValsetRaw(items[i].key, items[i].value)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool GPSDriverUBX::cfgValsetKeys(const uint32_t *keys, size_t count, uint8_t value)
+{
+	for (size_t i = 0; i < count; i++) {
+		if (!cfgValsetRaw(keys[i], value)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool GPSDriverUBX::cfgValsetPortKeys(const uint32_t *keys, size_t count, uint8_t value)
+{
+	for (size_t i = 0; i < count; i++) {
+		if (!cfgValsetPort(keys[i], value)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+bool GPSDriverUBX::cfgValsetUart2Keys(const uint32_t *keys, size_t count, uint8_t value)
+{
+	for (size_t i = 0; i < count; i++) {
+		if (!cfgValsetUart2(keys[i], value)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 int GPSDriverUBX::restartSurveyInPreV27()
 {
 	UBX_DEBUG("restartSurveyInPreV27");
@@ -1488,12 +1532,7 @@ int GPSDriverUBX::restartSurveyIn()
 
 	//disable RTCM output
 	initCfgValset();
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 0);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 0);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 0);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 0);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, 0);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 0);
+	cfgValsetPort(RTCM_BASE_MSGOUT_I2C, 0);
 	sendCfgValset();
 	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 
@@ -2904,12 +2943,7 @@ GPSDriverUBX::activateRTCMOutput(bool reduce_update_rate)
 			cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, 1000);
 		}
 
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 1);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 1);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 1);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 1);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, 1);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 1);
+		cfgValsetPort(RTCM_BASE_MSGOUT_I2C, 1);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 0);
 
 		if (!sendCfgValset()) {

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -1340,10 +1340,13 @@ int GPSDriverUBX::initCfgValset()
 	return sizeof(*header) - sizeof(header->cfgData);
 }
 
-template<typename T>
-bool GPSDriverUBX::cfgValset(uint32_t key_id, T value, int &msg_size)
+bool GPSDriverUBX::cfgValsetRaw(uint32_t key_id, uint32_t value, int &msg_size)
 {
-	if (msg_size + sizeof(key_id) + sizeof(value) > sizeof(_tx_cfg_valset_buf)) {
+	// Size field: 1 = L, 2 = U1/I1/E1/X1, 3 = 2 bytes, 4 = 4 bytes (5 = 8 bytes, unsupported here)
+	const unsigned size_field = (key_id >> 28) & 0x7;
+	const unsigned value_size = (size_field <= 2) ? 1 : (size_field == 3) ? 2 : 4;
+
+	if (msg_size + sizeof(key_id) + value_size > sizeof(_tx_cfg_valset_buf)) {
 		// If this ever fires, either bump UBX_CFG_VALSET_BUF_SIZE or split the
 		// batch into multiple CFG-VALSET messages at the call site.
 		UBX_WARN("buf for CFG_VALSET too small");
@@ -1352,8 +1355,9 @@ bool GPSDriverUBX::cfgValset(uint32_t key_id, T value, int &msg_size)
 
 	memcpy(_tx_cfg_valset_buf + msg_size, &key_id, sizeof(key_id));
 	msg_size += sizeof(key_id);
-	memcpy(_tx_cfg_valset_buf + msg_size, &value, sizeof(value));
-	msg_size += sizeof(value);
+	// little-endian: the low value_size bytes of value are the narrower type's bytes
+	memcpy(_tx_cfg_valset_buf + msg_size, &value, value_size);
+	msg_size += value_size;
 	return true;
 }
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -605,11 +605,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_NMEA, 0);
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -623,9 +619,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_SPARTN, enable_corrections_in);
 		}
 
-		if (sendCfgValset()) {
-			(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
-		}
+		sendCfgValsetAcked(false);
 	}
 
 	/* set configuration parameters */
@@ -689,11 +683,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_NAV, 1);
 	cfgValset<uint8_t>(UBX_CFG_KEY_RATE_TIMEREF, 0);
 
-	if (!sendCfgValset()) {
-		return -1;
-	}
-
-	if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+	if (sendCfgValsetAcked() < 0) {
 		return -1;
 	}
 
@@ -705,9 +695,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	initCfgValset();
 	cfgValset(odo_keys, 0);
 
-	if (sendCfgValset()) {
-		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
-	}
+	sendCfgValsetAcked(false);
 
 	// RTK (optional, as only RTK devices like F9P support it)
 	initCfgValset();
@@ -921,12 +909,8 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			}
 		}
 
-		if (!sendCfgValset()) {
-			UBX_DEBUG("UBX GNSS config send failed");
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
+			UBX_DEBUG("UBX GNSS config failed");
 			return -1;
 		}
 
@@ -994,11 +978,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	};
 	cfgValsetPort(unused_msgout, 0);
 
-	if (!sendCfgValset()) {
-		return -1;
-	}
-
-	if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+	if (sendCfgValsetAcked() < 0) {
 		return -1;
 	}
 
@@ -1047,11 +1027,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 					   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_RTCM3X);
 		}
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1061,9 +1037,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_SPARTN,
 					   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_RTCM3X);
 
-			if (sendCfgValset()) {
-				(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
-			}
+			sendCfgValsetAcked(false);
 		}
 	}
 
@@ -1079,11 +1053,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1); // GLONASS bias
 		cfgValset(RTCM_MSM7_UART1, 1);
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1106,11 +1076,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset(rover_uart2);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1145,11 +1111,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1);
 		}
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1168,11 +1130,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		initCfgValset();
 		cfgValset(rover_uart1);
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1200,11 +1158,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1, 1);
 		}
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1226,11 +1180,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		cfgValset(gcs_uart2);
 		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1249,9 +1199,7 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 			initCfgValset();
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_ENABLED, 1);
 
-			if (sendCfgValset()) {
-				(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
-			}
+			sendCfgValsetAcked(false);
 
 			// Input stays open so u-center can poll MON-VER and drive the configuration view
 			static constexpr CfgValsetItem ucenter_uart2[] = {
@@ -1341,6 +1289,15 @@ void GPSDriverUBX::initCfgValset()
 bool GPSDriverUBX::sendCfgValset()
 {
 	return sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, _tx_cfg_valset_size);
+}
+
+int GPSDriverUBX::sendCfgValsetAcked(bool report_ack_error)
+{
+	if (!sendCfgValset()) {
+		return -1;
+	}
+
+	return waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, report_ack_error);
 }
 
 bool GPSDriverUBX::cfgValsetRaw(uint32_t key_id, uint32_t value)
@@ -1533,8 +1490,7 @@ int GPSDriverUBX::restartSurveyIn()
 	//disable RTCM output
 	initCfgValset();
 	cfgValsetPort(RTCM_BASE_MSGOUT_I2C, 0);
-	sendCfgValset();
-	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
+	sendCfgValsetAcked(false);
 
 	if (_base_settings.type == BaseSettingsType::survey_in) {
 		UBX_DEBUG("Starting Survey-in");
@@ -1545,11 +1501,7 @@ int GPSDriverUBX::restartSurveyIn()
 		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT, _base_settings.settings.survey_in.acc_limit);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 5);
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 
@@ -1571,11 +1523,7 @@ int GPSDriverUBX::restartSurveyIn()
 		cfgValset<int8_t>(UBX_CFG_KEY_TMODE_HEIGHT_HP, alt64 % 100 /* 0.1mm */);
 		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_FIXED_POS_ACC, (uint32_t)(settings.position_accuracy * 10.f));
 
-		if (!sendCfgValset()) {
-			return -1;
-		}
-
-		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) < 0) {
+		if (sendCfgValsetAcked() < 0) {
 			return -1;
 		}
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -160,22 +160,22 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 			}
 
 			// try CFG-VALSET: if we get an ACK we know we can use protocol version 27+
-			int cfg_valset_msg_size = initCfgValset();
+			initCfgValset();
 			// UART1
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_STOPBITS, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_DATABITS, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_PARITY, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_STOPBITS, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_DATABITS, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1_PARITY, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_NMEA, 0);
 			// TODO: are we ever connected to UART2?
 
 			// Note: USB protocol settings are handled later in the configureDevice function.
 
 			bool cfg_valset_success = false;
 
-			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+			if (sendCfgValset()) {
 
 				// Note: The M10 comes up sending NMEA sentences at 9600. It can't
 				// respond with an ACK until the current sentence has completed transmission.
@@ -190,10 +190,10 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 			if (cfg_valset_success) {
 				_proto_ver_27_or_higher = true;
 				// Now we only have to change the baudrate
-				cfg_valset_msg_size = initCfgValset();
-				cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART1_BAUDRATE, desired_baudrate, cfg_valset_msg_size);
+				initCfgValset();
+				cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART1_BAUDRATE, desired_baudrate);
 
-				if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+				if (!sendCfgValset()) {
 					continue;
 				}
 
@@ -279,19 +279,19 @@ GPSDriverUBX::configure(unsigned &baudrate, const GPSConfig &config)
 		}
 
 		// try CFG-VALSET: if we get an ACK we know we can use protocol version 27+
-		int cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_ENABLED, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_MAXFF, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X, _output_mode == OutputMode::RTCM ? 0 : 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X, _output_mode == OutputMode::GPS ? 0 : 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA, 0, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_ENABLED, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_SPI_MAXFF, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_RTCM3X, _output_mode == OutputMode::RTCM ? 0 : 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_NMEA, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_RTCM3X, _output_mode == OutputMode::GPS ? 0 : 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIOUTPROT_NMEA, 0);
 
 		bool cfg_valset_success = false;
 
-		if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (sendCfgValset()) {
 
 			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, true) == 0) {
 				cfg_valset_success = true;
@@ -557,29 +557,29 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	// There is no RTCM or USB interface on M10
 	if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
 
-		int cfg_valset_msg_size = initCfgValset();
+		initCfgValset();
 
 		const uint8_t enable_corrections_in = (_output_mode == OutputMode::RTCM) ? 0 : 1;
 
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, enable_corrections_in, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, enable_corrections_in);
 
 		if (_output_mode != OutputMode::GPS) {
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1);
 		}
 
 		// USB
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_RTCM3X, enable_corrections_in, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_UBX, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_RTCM3X, enable_corrections_in);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_NMEA, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_UBX, 1);
 
 		if (_output_mode != OutputMode::GPS) {
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_RTCM3X, 1);
 		}
 
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_NMEA, 0, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBOUTPROT_NMEA, 0);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -589,36 +589,35 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 		// Optional SPARTN input (PointPerfect). Sent separately so modules without
 		// SPARTN support can NACK without failing the rest of configuration.
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_SPARTN, enable_corrections_in, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_SPARTN, enable_corrections_in, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_SPARTN, enable_corrections_in);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_USBINPROT_SPARTN, enable_corrections_in);
 
 		if (_interface == Interface::SPI) {
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_SPARTN, enable_corrections_in, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_SPIINPROT_SPARTN, enable_corrections_in);
 		}
 
-		if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (sendCfgValset()) {
 			(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 		}
 	}
 
 	/* set configuration parameters */
-	int cfg_valset_msg_size = initCfgValset();
-	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_FIXMODE, 3 /* Auto 2d/3d */, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_UTCSTANDARD, 3 /* USNO (U.S. Naval Observatory derived from GPS) */,
-			   cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_DYNMODEL, _dyn_model, cfg_valset_msg_size);
+	initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_FIXMODE, 3 /* Auto 2d/3d */);
+	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_UTCSTANDARD, 3 /* USNO (U.S. Naval Observatory derived from GPS) */);
+	cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_DYNMODEL, _dyn_model);
 
 	if (_min_cno != 0) {
-		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_INFIL_MINCNO, _min_cno, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_INFIL_MINCNO, _min_cno);
 	}
 
 	if (_min_elev != 0) {
-		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_INFIL_MINELEV, _min_elev, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_INFIL_MINELEV, _min_elev);
 	}
 
 	if (_dgnss_timeout != 0) {
-		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_CONSTR_DGNSSTO, _dgnss_timeout, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_NAVSPG_CONSTR_DGNSSTO, _dgnss_timeout);
 	}
 
 	// measurement rate
@@ -660,11 +659,11 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		}
 	}
 
-	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, rate_meas, cfg_valset_msg_size);
-	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_NAV, 1, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_RATE_TIMEREF, 0, cfg_valset_msg_size);
+	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, rate_meas);
+	cfgValset<uint16_t>(UBX_CFG_KEY_RATE_NAV, 1);
+	cfgValset<uint8_t>(UBX_CFG_KEY_RATE_TIMEREF, 0);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+	if (!sendCfgValset()) {
 		return -1;
 	}
 
@@ -674,32 +673,32 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	// Disable odometer. Separate, non-fatal VALSET: CFG-ODO-* was removed on the
 	// F20 platform (ZED-X20P HPG 2.10+), so a NAK here must not abort config.
-	cfg_valset_msg_size = initCfgValset();
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_COG, 0, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPVEL, 0, cfg_valset_msg_size);
-	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPCOG, 0, cfg_valset_msg_size);
+	initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_ODO, 0);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_USE_COG, 0);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPVEL, 0);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ODO_OUTLPCOG, 0);
 
-	if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+	if (sendCfgValset()) {
 		waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 	}
 
 	// RTK (optional, as only RTK devices like F9P support it)
-	cfg_valset_msg_size = initCfgValset();
-	cfgValset<uint8_t>(UBX_CFG_KEY_NAVHPG_DGNSSMODE, 3 /* RTK Fixed */, cfg_valset_msg_size);
+	initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_KEY_NAVHPG_DGNSSMODE, 3 /* RTK Fixed */);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+	if (!sendCfgValset()) {
 		return -1;
 	}
 
 	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 
-	cfg_valset_msg_size = initCfgValset();
+	initCfgValset();
 
 	// enable jamming monitor
-	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1, cfg_valset_msg_size);
+	cfgValset<uint8_t>(UBX_CFG_KEY_ITFM_ENABLE, 1);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+	if (!sendCfgValset()) {
 		return -1;
 	}
 
@@ -708,10 +707,10 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	// configure jamming detection sensitivity (CFG-SEC-JAMDET_SENSITIVITY_HI)
 	// Note: This configuration key may not be supported on older firmware versions.
 	// If NACKed, we just continue - the default sensitivity will be used.
-	cfg_valset_msg_size = initCfgValset();
-	cfgValset<uint8_t>(UBX_CFG_KEY_SEC_JAMDET_SENSITIVITY_HI, _jam_det_sensitivity_hi ? 1 : 0, cfg_valset_msg_size);
+	initCfgValset();
+	cfgValset<uint8_t>(UBX_CFG_KEY_SEC_JAMDET_SENSITIVITY_HI, _jam_det_sensitivity_hi ? 1 : 0);
 
-	if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+	if (sendCfgValset()) {
 		if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
 			UBX_WARN("CFG-SEC-JAMDET_SENSITIVITY_HI not supported by this receiver");
 		}
@@ -723,139 +722,139 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	//       2.1.1.3 GNSS signal configuration for details on some restrictions.
 	//       Implementing these restrictions are a TODO item for M10.
 	if (static_cast<int32_t>(config.gnss_systems) != 0) {
-		cfg_valset_msg_size = initCfgValset();
+		initCfgValset();
 
 		// GPS and QZSS should always be enabled and disabled together, according to uBlox
 		if (config.gnss_systems & GNSSSystemsMask::ENABLE_GPS) {
 			UBX_DEBUG("GNSS Systems: Use GPS + QZSS");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_ENA, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_ENA, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, 1);
 			UBX_DEBUG("GNSS Systems: Enable QZSS L1CA");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L1CA_ENA, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L1CA_ENA, 1);
 			UBX_DEBUG("GNSS Systems: Enable QZSS L1S");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L1S_ENA, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L1S_ENA, 1);
 
 			if (_board == Board::u_blox_X20) {
 				UBX_DEBUG("GNSS Systems: Use GPS L2C + L5, QZSS L2C + L5");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L2C_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L5_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L2C_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L5_ENA, 1);
 
 			} else if (_board == Board::u_blox9_F9P_L1L2) {
 				UBX_DEBUG("GNSS Systems: Use GPS L2C");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 1);
 				UBX_DEBUG("GNSS Systems: Enable QZSS L2C");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L2C_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L2C_ENA, 1);
 
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Use GPS L5");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 1);
 				UBX_DEBUG("GNSS Systems: Enable GPS L5 health override");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1);
 				UBX_DEBUG("GNSS Systems: Use QZSS L5");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L5_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_L5_ENA, 1);
 			}
 
 		} else {
 			UBX_DEBUG("GNSS Systems: Disable GPS + QZSS");
 
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_ENA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_ENA, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_QZSS_ENA, 0);
 
 			if (_board == Board::u_blox_X20) {
 				UBX_DEBUG("GNSS Systems: Disable GPS L2C + L5");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 0, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 0, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 0);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 0);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 0);
 
 			} else if (_board == Board::u_blox9_F9P_L1L2) {
 				UBX_DEBUG("GNSS Systems: Disable GPS L2C");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L2C_ENA, 0);
 
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Disable GPS L5");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 0, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GPS_L5_ENA, 0);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 0);
 			}
 		}
 
 		if (config.gnss_systems & GNSSSystemsMask::ENABLE_GALILEO) {
 			UBX_DEBUG("GNSS Systems: Use Galileo");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_ENA, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_ENA, 1);
 
 			if (_board == Board::u_blox_X20) {
 				UBX_DEBUG("GNSS Systems: Use Galileo E5A + E6");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E6_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E6_ENA, 1);
 
 			} else if (_board == Board::u_blox9_F9P_L1L2) {
 				UBX_DEBUG("GNSS Systems: Use Galileo E5B");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5B_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5B_ENA, 1);
 
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Use Galileo E5A");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 1);
 			}
 
 		} else {
 			UBX_DEBUG("GNSS Systems: Disable Galileo");
 
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_ENA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_ENA, 0);
 
 			if (_board == Board::u_blox_X20) {
 				UBX_DEBUG("GNSS Systems: Disable Galileo E5A + E6");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 0, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E6_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 0);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E6_ENA, 0);
 
 			} else if (_board == Board::u_blox9_F9P_L1L2) {
 				UBX_DEBUG("GNSS Systems: Disable Galileo E5B");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5B_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5B_ENA, 0);
 
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Disable Galileo E5A");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GAL_E5A_ENA, 0);
 			}
 		}
 
 		if (config.gnss_systems & GNSSSystemsMask::ENABLE_BEIDOU) {
 			UBX_DEBUG("GNSS Systems: Use BeiDou");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_ENA, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_ENA, 1);
 
 			if (_board == Board::u_blox_X20) {
 				UBX_DEBUG("GNSS Systems: Use BeiDou B1C + B2A + B3");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B1C_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B3_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B1C_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B3_ENA, 1);
 
 			} else if (_board == Board::u_blox9_F9P_L1L2) {
 				UBX_DEBUG("GNSS Systems: Use BeiDou B2");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2_ENA, 1);
 
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Use BeiDou B2A");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 1);
 			}
 
 		} else {
 			UBX_DEBUG("GNSS Systems: Disable BeiDou");
 
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_ENA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_ENA, 0);
 
 			if (_board == Board::u_blox_X20) {
 				UBX_DEBUG("GNSS Systems: Disable BeiDou B1C + B2A + B3");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B1C_ENA, 0, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 0, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B3_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B1C_ENA, 0);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 0);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B3_ENA, 0);
 
 			} else if (_board == Board::u_blox9_F9P_L1L2) {
 				UBX_DEBUG("GNSS Systems: Disable BeiDou B2");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2_ENA, 0);
 
 			} else if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5) {
 				UBX_DEBUG("GNSS Systems: Disable BeiDou B2A");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_BDS_B2A_ENA, 0);
 			}
 		}
 
@@ -863,22 +862,22 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		if (_board != Board::u_blox10_L1L5 && _board != Board::u_blox_X20) {
 			if (config.gnss_systems & GNSSSystemsMask::ENABLE_GLONASS) {
 				UBX_DEBUG("GNSS Systems: Use GLONASS");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L1_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L1_ENA, 1);
 
 				if (_board == Board::u_blox9_F9P_L1L2) {
 					UBX_DEBUG("GNSS Systems: Use GLONASS L2C");
-					cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L2_ENA, 1, cfg_valset_msg_size);
+					cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L2_ENA, 1);
 				}
 
 			} else {
 				UBX_DEBUG("GNSS Systems: Disable GLONASS");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_ENA, 0, cfg_valset_msg_size);
-				// cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L1_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_ENA, 0);
+				// cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L1_ENA, 0);
 
 				if (_board == Board::u_blox9_F9P_L1L2) {
 					UBX_DEBUG("GNSS Systems: Disable GLONASS L2C");
-					cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L2_ENA, 0, cfg_valset_msg_size);
+					cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_GLO_L2_ENA, 0);
 				}
 			}
 		}
@@ -886,17 +885,17 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		if (_board == Board::u_blox9_F9P_L1L5 || _board == Board::u_blox10_L1L5 || _board == Board::u_blox_X20) {
 			if (config.gnss_systems & GNSSSystemsMask::ENABLE_NAVIC) {
 				UBX_DEBUG("GNSS Systems: Use NavIC");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_ENA, 1, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_L5_ENA, 1, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_ENA, 1);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_L5_ENA, 1);
 
 			} else {
 				UBX_DEBUG("GNSS Systems: Disable NavIC");
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_ENA, 0, cfg_valset_msg_size);
-				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_L5_ENA, 0, cfg_valset_msg_size);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_ENA, 0);
+				cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_NAVIC_L5_ENA, 0);
 			}
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			UBX_DEBUG("UBX GNSS config send failed");
 			return -1;
 		}
@@ -906,18 +905,18 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		}
 
 		// send SBAS config separately, because it seems to be buggy (with u-center, too)
-		cfg_valset_msg_size = initCfgValset();
+		initCfgValset();
 
 		if (config.gnss_systems & GNSSSystemsMask::ENABLE_SBAS) {
 			UBX_DEBUG("GNSS Systems: Use SBAS");
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_ENA, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_L1CA_ENA, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_ENA, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_L1CA_ENA, 1);
 
 		} else {
-			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_ENA, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_SBAS_ENA, 0);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -925,12 +924,12 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_board == Board::u_blox10_L1L5 || _board == Board::u_blox_X20) {
 		// Enable L5 health override, use version 0 of the message
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_SIGNAL_L5_HEALTH_OVERRIDE, 1);
 
 		UBX_DEBUG("Enabling L5 health override");
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -939,25 +938,24 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	// Configure message rates
 	// Send a new CFG-VALSET message to make sure it does not get too large
-	cfg_valset_msg_size = initCfgValset();
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
+	initCfgValset();
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1);
 
 	// There is no RTCM on M10 and M9* (except F9P)
 	if (_board != Board::u_blox10 && _board != Board::u_blox9 && _board != Board::u_blox10_L1L5) {
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1, cfg_valset_msg_size);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1);
 		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_RELPOSNED_I2C,
-			      _mode == UBXMode::RoverWithMovingBaseUART2 || _mode == UBXMode::RoverWithMovingBaseUART1 ? 1 : 0,
-			      cfg_valset_msg_size);
+			      _mode == UBXMode::RoverWithMovingBaseUART2 || _mode == UBXMode::RoverWithMovingBaseUART1 ? 1 : 0);
 	}
 
 	_use_nav_pvt = true;
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, (_satellite_info != nullptr) ? 10 : 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_STATUS_I2C, 1, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1, cfg_valset_msg_size);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, (_satellite_info != nullptr) ? 10 : 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_STATUS_I2C, 1);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1);
 
 	if ((_board == Board::u_blox9) || (_board == Board::u_blox9_F9P_L1L2) || (_board == Board::u_blox9_F9P_L1L5)) {
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1, cfg_valset_msg_size);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1);
 	}
 
 	// Explicitly disable the messages this driver never consumes. We do not enable them,
@@ -965,11 +963,11 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	// (u-center, or another firmware such as ArduPilot, which writes CFG-VALSET to the
 	// BBR/FLASH layers). Clearing them here rather than waiting for payloadRxInit() to
 	// notice them avoids wasting UART bandwidth on every boot.
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C, 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C, 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C, 0, cfg_valset_msg_size);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_TIMEGPS_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_RAWX_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_RXM_SFRBX_I2C, 0);
 
-	if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+	if (!sendCfgValset()) {
 		return -1;
 	}
 
@@ -985,11 +983,11 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 					       || (_mode == UBXMode::RoverWithMovingBaseUART1)
 					       || isMovingBase();
 
-		cfg_valset_msg_size = initCfgValset();
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_DAHEADING_I2C, moving_base_setup ? 0 : 1, cfg_valset_msg_size);
-		cfgValset<int32_t>(UBX_CFG_KEY_NAVSPG_DAHEADING_OFFSET, 0, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_DAHEADING_I2C, moving_base_setup ? 0 : 1);
+		cfgValset<int32_t>(UBX_CFG_KEY_NAVSPG_DAHEADING_OFFSET, 0);
 
-		if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (sendCfgValset()) {
 			if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
 				UBX_DEBUG("NAV-DAHEADING not supported by this receiver");
 			}
@@ -999,30 +997,30 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	if (_interface == Interface::UART || _interface == Interface::SPI) {
 
 		// Enable/Disable GPS protocols at I2C interface
-		cfg_valset_msg_size = initCfgValset();
+		initCfgValset();
 
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_UBX,
-				   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_UBX, cfg_valset_msg_size);
+				   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_UBX);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_NMEA,
-				   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_NMEA, cfg_valset_msg_size);
+				   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_NMEA);
 
 		// There is no RTCM on M10
 		if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_RTCM3X,
-					   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_RTCM3X, cfg_valset_msg_size);
+					   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_RTCM3X);
 		}
 
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_UBX,
-				   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_UBX, cfg_valset_msg_size);
+				   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_UBX);
 		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_NMEA,
-				   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_NMEA, cfg_valset_msg_size);
+				   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_NMEA);
 
 		if ((_board == Board::u_blox9_F9P_L1L2) || (_board == Board::u_blox9_F9P_L1L5)) {
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2COUTPROT_RTCM3X,
-					   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_RTCM3X, cfg_valset_msg_size);
+					   config.interface_protocols & InterfaceProtocolsMask::I2C_OUT_PROT_RTCM3X);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1032,11 +1030,11 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 		// Optional SPARTN on I2C (best-effort; NACK is fine on non-SPARTN firmware)
 		if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
-			cfg_valset_msg_size = initCfgValset();
+			initCfgValset();
 			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_I2CINPROT_SPARTN,
-					   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_RTCM3X, cfg_valset_msg_size);
+					   config.interface_protocols & InterfaceProtocolsMask::I2C_IN_PROT_RTCM3X);
 
-			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+			if (sendCfgValset()) {
 				(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 			}
 		}
@@ -1044,20 +1042,20 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	if (_mode == UBXMode::Normal && _ppk_output) {
 		UBX_DEBUG("Configuring Normal with MSM7 output");
-		cfg_valset_msg_size = initCfgValset();
+		initCfgValset();
 
 		// Enable output protocols on UART1
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1);
 
 		// Configure MSM7 message outputs on UART1
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1, cfg_valset_msg_size); // GLONASS bias
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 1, cfg_valset_msg_size); // GPS MSM7
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 1, cfg_valset_msg_size); // GLONASS MSM7
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 1, cfg_valset_msg_size); // Galileo MSM7
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 1, cfg_valset_msg_size); // BeiDou MSM7
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1); // GLONASS bias
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 1); // GPS MSM7
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 1); // GLONASS MSM7
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 1); // Galileo MSM7
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 1); // BeiDou MSM7
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1067,21 +1065,21 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_mode == UBXMode::RoverWithStaticBaseUART2 || _mode == UBXMode::RoverWithMovingBaseUART2) {
 		UBX_DEBUG("Configuring UART2 for rover");
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0);
 		// enable RTCM input on uart2 + set baudrate
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0);
+		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1095,51 +1093,51 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	} else if (_mode == UBXMode::MovingBaseUART2) {
 		UBX_DEBUG("Configuring UART2 for moving base");
 		// enable RTCM output on uart2 + set baudrate
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART2, 1, cfg_valset_msg_size); // GLONASS bias
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 1);
+		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART2, 1); // GLONASS bias
 
 		if (_ppk_output) {
 			UBX_DEBUG("Enabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, 1, cfg_valset_msg_size); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2, 1, cfg_valset_msg_size); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, 1, cfg_valset_msg_size); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2, 1, cfg_valset_msg_size); // BeiDou MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, 1); // GPS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2, 1); // GLONASS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, 1); // Galileo MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2, 1); // BeiDou MSM7
 			UBX_DEBUG("Disabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART2, 0, cfg_valset_msg_size); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART2, 0, cfg_valset_msg_size); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART2, 0, cfg_valset_msg_size); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART2, 0, cfg_valset_msg_size); // BeiDou MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART2, 0); // GPS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART2, 0); // GLONASS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART2, 0); // Galileo MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART2, 0); // BeiDou MSM4
 
 		} else {
 			UBX_DEBUG("Enabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART2, 1, cfg_valset_msg_size); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART2, 1, cfg_valset_msg_size); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART2, 1, cfg_valset_msg_size); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART2, 1, cfg_valset_msg_size); // BeiDou MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART2, 1); // GPS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART2, 1); // GLONASS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART2, 1); // Galileo MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART2, 1); // BeiDou MSM4
 			UBX_DEBUG("Disabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, 0, cfg_valset_msg_size); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2, 0, cfg_valset_msg_size); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, 0, cfg_valset_msg_size); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2, 0, cfg_valset_msg_size); // BeiDou MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART2, 0); // GPS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART2, 0); // GLONASS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART2, 0); // Galileo MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART2, 0); // BeiDou MSM7
 		}
 
 		// 4072.0 marks the base as moving, without it the rover solves against it as a
 		// static base and never reports a heading. The F9P-15B doesn't support 4072.
 		if (_board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox_X20) {
 			UBX_DEBUG("Configuring ublox 4072");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART2, 1);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1152,14 +1150,14 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	} else if (_mode == UBXMode::RoverWithMovingBaseUART1) {
 		UBX_DEBUG("Configuring UART1 for rover");
 		// heading output period 1 second
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 0);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1170,47 +1168,47 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 	} else if (_mode == UBXMode::MovingBaseUART1) {
 		UBX_DEBUG("Configuring UART1 for moving base");
 		// enable RTCM output on uart1
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1, cfg_valset_msg_size); // GLONASS bias
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_RTCM3X, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1INPROT_NMEA, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_UBX, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART1OUTPROT_RTCM3X, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_UART1, 1); // GLONASS bias
 
 		if (_ppk_output) {
 			UBX_DEBUG("Enabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 1, cfg_valset_msg_size); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 1, cfg_valset_msg_size); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 1, cfg_valset_msg_size); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 1, cfg_valset_msg_size); // BeiDou MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 1); // GPS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 1); // GLONASS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 1); // Galileo MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 1); // BeiDou MSM7
 			UBX_DEBUG("Disabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART1, 0, cfg_valset_msg_size); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART1, 0, cfg_valset_msg_size); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART1, 0, cfg_valset_msg_size); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART1, 0, cfg_valset_msg_size); // BeiDou MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART1, 0); // GPS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART1, 0); // GLONASS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART1, 0); // Galileo MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART1, 0); // BeiDou MSM4
 
 		} else {
 			UBX_DEBUG("Enabling MSM4");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART1, 1, cfg_valset_msg_size); // GPS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART1, 1, cfg_valset_msg_size); // GLONASS MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART1, 1, cfg_valset_msg_size); // Galileo MSM4
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART1, 1, cfg_valset_msg_size); // BeiDou MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1074_UART1, 1); // GPS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1084_UART1, 1); // GLONASS MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1094_UART1, 1); // Galileo MSM4
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1124_UART1, 1); // BeiDou MSM4
 			UBX_DEBUG("Disabling MSM7");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 0, cfg_valset_msg_size); // GPS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 0, cfg_valset_msg_size); // GLONASS MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 0, cfg_valset_msg_size); // Galileo MSM7
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 0, cfg_valset_msg_size); // BeiDou MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_UART1, 0); // GPS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_UART1, 0); // GLONASS MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_UART1, 0); // Galileo MSM7
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_UART1, 0); // BeiDou MSM7
 		}
 
 		// 4072.0 marks the base as moving, without it the rover solves against it as a
 		// static base and never reports a heading. The F9P-15B doesn't support 4072.
 		if (_board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox_X20) {
 			UBX_DEBUG("Configuring ublox 4072");
-			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1, 1, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE4072_0_UART1, 1);
 		}
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1220,19 +1218,19 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 	} else if (_mode == UBXMode::GroundControlStation) {
 		UBX_DEBUG("Configuring UART2 for Ground Control Station");
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 1, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 1);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 0);
+		cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0);
+		cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1252,27 +1250,27 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 		} else {
 			// On its own, because the platforms that wire UART2 permanently on have no such key
 			// and a NAK would otherwise take the port settings down with it.
-			cfg_valset_msg_size = initCfgValset();
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_ENABLED, 1, cfg_valset_msg_size);
+			initCfgValset();
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_ENABLED, 1);
 
-			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+			if (sendCfgValset()) {
 				(void)waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 			}
 
-			cfg_valset_msg_size = initCfgValset();
-			cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0, cfg_valset_msg_size);
+			initCfgValset();
+			cfgValset<uint32_t>(UBX_CFG_KEY_CFG_UART2_BAUDRATE, uart2_baudrate);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_STOPBITS, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_DATABITS, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2_PARITY, 0);
 			// Input stays open so u-center can poll MON-VER and drive the configuration view
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 1, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 0, cfg_valset_msg_size);
-			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0, cfg_valset_msg_size);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_UBX, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_NMEA, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2INPROT_RTCM3X, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_UBX, 1);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_NMEA, 0);
+			cfgValset<uint8_t>(UBX_CFG_KEY_CFG_UART2OUTPROT_RTCM3X, 0);
 
-			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+			if (sendCfgValset()) {
 				if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
 					UBX_WARN("UART2 port config for u-center rejected");
 				}
@@ -1280,24 +1278,24 @@ int GPSDriverUBX::configureDevice(const GPSConfig &config, const int32_t uart2_b
 
 			// Message rates are per port, so the set enabled for the driver's own port leaves UART2
 			// silent. u-center shows nothing at all without these.
-			cfg_valset_msg_size = initCfgValset();
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1, cfg_valset_msg_size);
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1, cfg_valset_msg_size);
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_STATUS_I2C, 1, cfg_valset_msg_size);
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1, cfg_valset_msg_size);
+			initCfgValset();
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_PVT_I2C, 1);
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_DOP_I2C, 1);
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_STATUS_I2C, 1);
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_MON_RF_I2C, 1);
 			// NAV-SAT is 12 bytes per satellite against ~250 for all of the above together, so it
 			// gets the same decimation the driver uses for itself rather than setting the link speed
-			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, 10, cfg_valset_msg_size);
+			cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_SAT_I2C, 10);
 
 			if (_board != Board::u_blox9) {
-				cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1, cfg_valset_msg_size);
+				cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_NAV_HPPOSLLH_I2C, 1);
 			}
 
 			if (_board == Board::u_blox9 || _board == Board::u_blox9_F9P_L1L2 || _board == Board::u_blox9_F9P_L1L5) {
-				cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1, cfg_valset_msg_size);
+				cfgValsetUart2(UBX_CFG_KEY_MSGOUT_UBX_RXM_RTCM_I2C, 1);
 			}
 
-			if (sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+			if (sendCfgValset()) {
 				if (waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false) < 0) {
 					UBX_WARN("UART2 message rates for u-center rejected");
 				}
@@ -1330,53 +1328,58 @@ const char *GPSDriverUBX::uart1Protocols(UBXMode mode, bool ppk_output)
 	return "UBX in/out";
 }
 
-int GPSDriverUBX::initCfgValset()
+void GPSDriverUBX::initCfgValset()
 {
 	static_assert(sizeof(_tx_cfg_valset_buf) >= sizeof(ubx_payload_tx_cfg_valset_t),
 		      "_tx_cfg_valset_buf must hold at least the CFG-VALSET header");
 	auto *header = reinterpret_cast<ubx_payload_tx_cfg_valset_t *>(_tx_cfg_valset_buf);
 	memset(_tx_cfg_valset_buf, 0, sizeof(_tx_cfg_valset_buf));
 	header->layers = UBX_CFG_LAYER_RAM;
-	return sizeof(*header) - sizeof(header->cfgData);
+	_tx_cfg_valset_size = sizeof(*header) - sizeof(header->cfgData);
 }
 
-bool GPSDriverUBX::cfgValsetRaw(uint32_t key_id, uint32_t value, int &msg_size)
+bool GPSDriverUBX::sendCfgValset()
+{
+	return sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, _tx_cfg_valset_size);
+}
+
+bool GPSDriverUBX::cfgValsetRaw(uint32_t key_id, uint32_t value)
 {
 	// Size field: 1 = L, 2 = U1/I1/E1/X1, 3 = 2 bytes, 4 = 4 bytes (5 = 8 bytes, unsupported here)
 	const unsigned size_field = (key_id >> 28) & 0x7;
 	const unsigned value_size = (size_field <= 2) ? 1 : (size_field == 3) ? 2 : 4;
 
-	if (msg_size + sizeof(key_id) + value_size > sizeof(_tx_cfg_valset_buf)) {
+	if (_tx_cfg_valset_size + sizeof(key_id) + value_size > sizeof(_tx_cfg_valset_buf)) {
 		// If this ever fires, either bump UBX_CFG_VALSET_BUF_SIZE or split the
 		// batch into multiple CFG-VALSET messages at the call site.
 		UBX_WARN("buf for CFG_VALSET too small");
 		return false;
 	}
 
-	memcpy(_tx_cfg_valset_buf + msg_size, &key_id, sizeof(key_id));
-	msg_size += sizeof(key_id);
+	memcpy(_tx_cfg_valset_buf + _tx_cfg_valset_size, &key_id, sizeof(key_id));
+	_tx_cfg_valset_size += sizeof(key_id);
 	// little-endian: the low value_size bytes of value are the narrower type's bytes
-	memcpy(_tx_cfg_valset_buf + msg_size, &value, value_size);
-	msg_size += value_size;
+	memcpy(_tx_cfg_valset_buf + _tx_cfg_valset_size, &value, value_size);
+	_tx_cfg_valset_size += value_size;
 	return true;
 }
 
-bool GPSDriverUBX::cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size)
+bool GPSDriverUBX::cfgValsetPort(uint32_t key_id, uint8_t value)
 {
 	if (_interface == Interface::SPI) {
-		if (!cfgValset<uint8_t>(key_id + 4, value, msg_size)) {
+		if (!cfgValset<uint8_t>(key_id + 4, value)) {
 			return false;
 		}
 
 	} else {
 		// enable on UART1 & USB (TODO: should we enable UART2 too? -> better would be to detect the port)
-		if (!cfgValset<uint8_t>(key_id + 1, value, msg_size)) {
+		if (!cfgValset<uint8_t>(key_id + 1, value)) {
 			return false;
 		}
 
 		// M10 has no USB
 		if (_board != Board::u_blox10 && _board != Board::u_blox10_L1L5) {
-			if (!cfgValset<uint8_t>(key_id + 3, value, msg_size)) {
+			if (!cfgValset<uint8_t>(key_id + 3, value)) {
 				return false;
 			}
 		}
@@ -1385,9 +1388,9 @@ bool GPSDriverUBX::cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size)
 	return true;
 }
 
-bool GPSDriverUBX::cfgValsetUart2(uint32_t key_id, uint8_t value, int &msg_size)
+bool GPSDriverUBX::cfgValsetUart2(uint32_t key_id, uint8_t value)
 {
-	return cfgValset<uint8_t>(key_id + 2, value, msg_size);
+	return cfgValset<uint8_t>(key_id + 2, value);
 }
 
 int GPSDriverUBX::restartSurveyInPreV27()
@@ -1484,26 +1487,26 @@ int GPSDriverUBX::restartSurveyIn()
 	UBX_DEBUG("restartSurveyIn");
 
 	//disable RTCM output
-	int cfg_valset_msg_size = initCfgValset();
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, 0, cfg_valset_msg_size);
-	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 0, cfg_valset_msg_size);
-	sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size);
+	initCfgValset();
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, 0);
+	cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 0);
+	sendCfgValset();
 	waitForAck(UBX_MSG_CFG_VALSET, UBX_CONFIG_TIMEOUT, false);
 
 	if (_base_settings.type == BaseSettingsType::survey_in) {
 		UBX_DEBUG("Starting Survey-in");
 
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_TMODE_MODE, 1 /* Survey-in */, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_SVIN_MIN_DUR, _base_settings.settings.survey_in.min_dur, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT, _base_settings.settings.survey_in.acc_limit, cfg_valset_msg_size);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 5, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_TMODE_MODE, 1 /* Survey-in */);
+		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_SVIN_MIN_DUR, _base_settings.settings.survey_in.min_dur);
+		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_SVIN_ACC_LIMIT, _base_settings.settings.survey_in.acc_limit);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 5);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -1515,22 +1518,21 @@ int GPSDriverUBX::restartSurveyIn()
 		UBX_DEBUG("Setting fixed base position");
 
 		const FixedPositionSettings &settings = _base_settings.settings.fixed_position;
-		cfg_valset_msg_size = initCfgValset();
-		cfgValset<uint8_t>(UBX_CFG_KEY_TMODE_MODE, 2 /* Fixed Mode */, cfg_valset_msg_size);
-		cfgValset<uint8_t>(UBX_CFG_KEY_TMODE_POS_TYPE, 1 /* Lat/Lon/Height */, cfg_valset_msg_size);
+		initCfgValset();
+		cfgValset<uint8_t>(UBX_CFG_KEY_TMODE_MODE, 2 /* Fixed Mode */);
+		cfgValset<uint8_t>(UBX_CFG_KEY_TMODE_POS_TYPE, 1 /* Lat/Lon/Height */);
 		int64_t lat64 = (int64_t)(settings.latitude * 1e9);
-		cfgValset<int32_t>(UBX_CFG_KEY_TMODE_LAT, (int32_t)(lat64 / 100), cfg_valset_msg_size);
-		cfgValset<int8_t>(UBX_CFG_KEY_TMODE_LAT_HP, lat64 % 100 /* range [-99, 99] */, cfg_valset_msg_size);
+		cfgValset<int32_t>(UBX_CFG_KEY_TMODE_LAT, (int32_t)(lat64 / 100));
+		cfgValset<int8_t>(UBX_CFG_KEY_TMODE_LAT_HP, lat64 % 100 /* range [-99, 99] */);
 		int64_t lon64 = (int64_t)(settings.longitude * 1e9);
-		cfgValset<int32_t>(UBX_CFG_KEY_TMODE_LON, (int32_t)(lon64 / 100), cfg_valset_msg_size);
-		cfgValset<int8_t>(UBX_CFG_KEY_TMODE_LON_HP, lon64 % 100 /* range [-99, 99] */, cfg_valset_msg_size);
+		cfgValset<int32_t>(UBX_CFG_KEY_TMODE_LON, (int32_t)(lon64 / 100));
+		cfgValset<int8_t>(UBX_CFG_KEY_TMODE_LON_HP, lon64 % 100 /* range [-99, 99] */);
 		int64_t alt64 = (int64_t)((double)settings.altitude * 1e4);
-		cfgValset<int32_t>(UBX_CFG_KEY_TMODE_HEIGHT, (int32_t)(alt64 / 100) /* cm */, cfg_valset_msg_size);
-		cfgValset<int8_t>(UBX_CFG_KEY_TMODE_HEIGHT_HP, alt64 % 100 /* 0.1mm */, cfg_valset_msg_size);
-		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_FIXED_POS_ACC, (uint32_t)(settings.position_accuracy * 10.f),
-				    cfg_valset_msg_size);
+		cfgValset<int32_t>(UBX_CFG_KEY_TMODE_HEIGHT, (int32_t)(alt64 / 100) /* cm */);
+		cfgValset<int8_t>(UBX_CFG_KEY_TMODE_HEIGHT_HP, alt64 % 100 /* 0.1mm */);
+		cfgValset<uint32_t>(UBX_CFG_KEY_TMODE_FIXED_POS_ACC, (uint32_t)(settings.position_accuracy * 10.f));
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 
@@ -2048,9 +2050,9 @@ GPSDriverUBX::payloadRxInit()
 					_disable_cmd_last = t;
 					UBX_DEBUG("ubx disabling msg 0x%04x (0x%04x)", SWAP16((unsigned)_rx_msg), (uint16_t)key_id);
 
-					int cfg_valset_msg_size = initCfgValset();
-					cfgValsetPort(key_id, 0, cfg_valset_msg_size);
-					sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size);
+					initCfgValset();
+					cfgValsetPort(key_id, 0);
+					sendCfgValset();
 				}
 			}
 
@@ -2950,21 +2952,21 @@ GPSDriverUBX::activateRTCMOutput(bool reduce_update_rate)
 	UBX_DEBUG("activateRTCMOutput");
 
 	if (_proto_ver_27_or_higher) {
-		int cfg_valset_msg_size = initCfgValset();
+		initCfgValset();
 
 		if (reduce_update_rate) {
-			cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, 1000, cfg_valset_msg_size);
+			cfgValset<uint16_t>(UBX_CFG_KEY_RATE_MEAS, 1000);
 		}
 
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 1, cfg_valset_msg_size);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 1, cfg_valset_msg_size);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 1, cfg_valset_msg_size);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 1, cfg_valset_msg_size);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, 1, cfg_valset_msg_size);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 1, cfg_valset_msg_size);
-		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 0, cfg_valset_msg_size);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1005_I2C, 1);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1077_I2C, 1);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1087_I2C, 1);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1230_I2C, 1);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1097_I2C, 1);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_RTCM_3X_TYPE1127_I2C, 1);
+		cfgValsetPort(UBX_CFG_KEY_MSGOUT_UBX_NAV_SVIN_I2C, 0);
 
-		if (!sendMessage(UBX_MSG_CFG_VALSET, _tx_cfg_valset_buf, cfg_valset_msg_size)) {
+		if (!sendCfgValset()) {
 			return -1;
 		}
 

--- a/src/ubx.cpp
+++ b/src/ubx.cpp
@@ -2477,8 +2477,6 @@ GPSDriverUBX::payloadRxDone()
 		if ((_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_VALIDDATE)
 		    && (_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_VALIDTIME)
 		    && (_buf.payload_rx_nav_pvt.valid & UBX_RX_NAV_PVT_VALID_FULLYRESOLVED)) {
-#ifndef NO_MKTIME
-			/* convert to unix timestamp */
 			tm timeinfo{};
 			timeinfo.tm_year	= _buf.payload_rx_nav_pvt.year - 1900;
 			timeinfo.tm_mon		= _buf.payload_rx_nav_pvt.month - 1;
@@ -2486,31 +2484,7 @@ GPSDriverUBX::payloadRxDone()
 			timeinfo.tm_hour	= _buf.payload_rx_nav_pvt.hour;
 			timeinfo.tm_min		= _buf.payload_rx_nav_pvt.min;
 			timeinfo.tm_sec		= _buf.payload_rx_nav_pvt.sec;
-
-
-			time_t epoch = mktime(&timeinfo);
-
-			if (epoch > GPS_EPOCH_SECS) {
-				// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-				// and control its drift. Since we rely on the HRT for our monotonic
-				// clock, updating it from time to time is safe.
-
-				timespec ts{};
-				ts.tv_sec = epoch;
-				ts.tv_nsec = _buf.payload_rx_nav_pvt.nano;
-
-				setClock(ts);
-
-				_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-				_gps_position->time_utc_usec += _buf.payload_rx_nav_pvt.nano / 1000;
-
-			} else {
-				_gps_position->time_utc_usec = 0;
-			}
-
-#else
-			_gps_position->time_utc_usec = 0;
-#endif
+			_gps_position->time_utc_usec = timeFromUtc(timeinfo, _buf.payload_rx_nav_pvt.nano);
 
 		} else {
 			// The struct is reused across messages, so without this a receiver
@@ -2619,8 +2593,6 @@ GPSDriverUBX::payloadRxDone()
 		UBX_TRACE_RXMSG("Rx NAV-TIMEUTC");
 
 		if (_buf.payload_rx_nav_timeutc.valid & UBX_RX_NAV_TIMEUTC_VALID_VALIDUTC) {
-#ifndef NO_MKTIME
-			// convert to unix timestamp
 			tm timeinfo {};
 			timeinfo.tm_year	= _buf.payload_rx_nav_timeutc.year - 1900;
 			timeinfo.tm_mon		= _buf.payload_rx_nav_timeutc.month - 1;
@@ -2628,33 +2600,7 @@ GPSDriverUBX::payloadRxDone()
 			timeinfo.tm_hour	= _buf.payload_rx_nav_timeutc.hour;
 			timeinfo.tm_min		= _buf.payload_rx_nav_timeutc.min;
 			timeinfo.tm_sec		= _buf.payload_rx_nav_timeutc.sec;
-			timeinfo.tm_isdst	= 0;
-
-			time_t epoch = mktime(&timeinfo);
-
-			// only set the time if it makes sense
-
-			if (epoch > GPS_EPOCH_SECS) {
-				// FMUv2+ boards have a hardware RTC, but GPS helps us to configure it
-				// and control its drift. Since we rely on the HRT for our monotonic
-				// clock, updating it from time to time is safe.
-
-				timespec ts{};
-				ts.tv_sec = epoch;
-				ts.tv_nsec = _buf.payload_rx_nav_timeutc.nano;
-
-				setClock(ts);
-
-				_gps_position->time_utc_usec = static_cast<uint64_t>(epoch) * 1000000ULL;
-				_gps_position->time_utc_usec += _buf.payload_rx_nav_timeutc.nano / 1000;
-
-			} else {
-				_gps_position->time_utc_usec = 0;
-			}
-
-#else
-			_gps_position->time_utc_usec = 0;
-#endif
+			_gps_position->time_utc_usec = timeFromUtc(timeinfo, _buf.payload_rx_nav_timeutc.nano);
 
 		} else {
 			// The struct is reused across messages, so without this a receiver

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1144,14 +1144,26 @@ private:
 	int configureDevicePreV27(const GNSSSystemsMask &gnssSystems);
 
 	/**
-	 * Add a configuration value to _tx_cfg_valset_buf and increase the message size msg_size as needed
+	 * Add a configuration value to _tx_cfg_valset_buf and increase the message size msg_size as needed.
+	 * The value width on the wire comes from the key ID's size field, not from T; T documents the
+	 * call site and must agree with the key.
 	 * @param key_id one of the UBX_CFG_KEY_* constants
 	 * @param value configuration value
 	 * @param msg_size CFG-VALSET message size: this is an input & output param
 	 * @return true on success, false if buffer too small
 	 */
 	template<typename T>
-	bool cfgValset(uint32_t key_id, T value, int &msg_size);
+	bool cfgValset(uint32_t key_id, T value, int &msg_size)
+	{
+		static_assert(sizeof(T) <= sizeof(uint32_t), "CFG-VALSET values wider than 4 bytes are not supported");
+		return cfgValsetRaw(key_id, static_cast<uint32_t>(value), msg_size);
+	}
+
+	/**
+	 * Non-template body for cfgValset(): appends key_id and the low N bytes of value, where N is
+	 * given by the key ID's size field (bits 28-30: 1 and 2 -> 1 byte, 3 -> 2 bytes, 4 -> 4 bytes).
+	 */
+	bool cfgValsetRaw(uint32_t key_id, uint32_t value, int &msg_size);
 
 	/**
 	 * Add a configuration value that is port-specific (MSGOUT messages).

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1164,6 +1164,28 @@ private:
 	 */
 	bool cfgValsetRaw(uint32_t key_id, uint32_t value);
 
+	/** A fixed key/value pair for cfgValset(items) */
+	struct CfgValsetItem {
+		uint32_t key;
+		uint8_t value;
+	} __attribute__((packed));
+
+	/**
+	 * Add a fixed list of 1-byte configuration values
+	 * @return true on success, false if buffer too small
+	 */
+	template<size_t N>
+	bool cfgValset(const CfgValsetItem(&items)[N]) { return cfgValsetItems(items, N); }
+	bool cfgValsetItems(const CfgValsetItem *items, size_t count);
+
+	/**
+	 * Add the same 1-byte value for a list of keys
+	 * @return true on success, false if buffer too small
+	 */
+	template<size_t N>
+	bool cfgValset(const uint32_t (&keys)[N], uint8_t value) { return cfgValsetKeys(keys, N, value); }
+	bool cfgValsetKeys(const uint32_t *keys, size_t count, uint8_t value);
+
 	/**
 	 * Add a configuration value that is port-specific (MSGOUT messages).
 	 * Note: Key ID must be the one for I2C, and the implementation assumes the
@@ -1176,6 +1198,11 @@ private:
 	 */
 	bool cfgValsetPort(uint32_t key_id, uint8_t value);
 
+	/** cfgValsetPort() for a list of I2C key IDs sharing one value */
+	template<size_t N>
+	bool cfgValsetPort(const uint32_t (&keys)[N], uint8_t value) { return cfgValsetPortKeys(keys, N, value); }
+	bool cfgValsetPortKeys(const uint32_t *keys, size_t count, uint8_t value);
+
 	/**
 	 * Add a port-specific (MSGOUT) configuration value for UART2, which is never the port this
 	 * driver talks on. Same key ordering assumption as cfgValsetPort().
@@ -1185,6 +1212,11 @@ private:
 	 * @return true on success, false if buffer too small
 	 */
 	bool cfgValsetUart2(uint32_t key_id, uint8_t value);
+
+	/** cfgValsetUart2() for a list of I2C key IDs sharing one value */
+	template<size_t N>
+	bool cfgValsetUart2(const uint32_t (&keys)[N], uint8_t value) { return cfgValsetUart2Keys(keys, N, value); }
+	bool cfgValsetUart2Keys(const uint32_t *keys, size_t count, uint8_t value);
 
 	/**
 	 * Reset the parse state machine for a fresh start

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1240,6 +1240,13 @@ private:
 	bool sendCfgValset();
 
 	/**
+	 * sendCfgValset() followed by waitForAck()
+	 * @param report_ack_error log a NAK or timeout
+	 * @return 0 on ACK, <0 if sending failed or no ACK was received
+	 */
+	int sendCfgValsetAcked(bool report_ack_error = true);
+
+	/**
 	 * Start or restart the survey-in procees. This is only used in RTCM ouput mode.
 	 * It will be called automatically after configuring.
 	 * @return 0 on success, <0 on error

--- a/src/ubx.h
+++ b/src/ubx.h
@@ -1144,26 +1144,25 @@ private:
 	int configureDevicePreV27(const GNSSSystemsMask &gnssSystems);
 
 	/**
-	 * Add a configuration value to _tx_cfg_valset_buf and increase the message size msg_size as needed.
+	 * Add a configuration value to the pending CFG-VALSET in _tx_cfg_valset_buf.
 	 * The value width on the wire comes from the key ID's size field, not from T; T documents the
 	 * call site and must agree with the key.
 	 * @param key_id one of the UBX_CFG_KEY_* constants
 	 * @param value configuration value
-	 * @param msg_size CFG-VALSET message size: this is an input & output param
 	 * @return true on success, false if buffer too small
 	 */
 	template<typename T>
-	bool cfgValset(uint32_t key_id, T value, int &msg_size)
+	bool cfgValset(uint32_t key_id, T value)
 	{
 		static_assert(sizeof(T) <= sizeof(uint32_t), "CFG-VALSET values wider than 4 bytes are not supported");
-		return cfgValsetRaw(key_id, static_cast<uint32_t>(value), msg_size);
+		return cfgValsetRaw(key_id, static_cast<uint32_t>(value));
 	}
 
 	/**
 	 * Non-template body for cfgValset(): appends key_id and the low N bytes of value, where N is
 	 * given by the key ID's size field (bits 28-30: 1 and 2 -> 1 byte, 3 -> 2 bytes, 4 -> 4 bytes).
 	 */
-	bool cfgValsetRaw(uint32_t key_id, uint32_t value, int &msg_size);
+	bool cfgValsetRaw(uint32_t key_id, uint32_t value);
 
 	/**
 	 * Add a configuration value that is port-specific (MSGOUT messages).
@@ -1173,10 +1172,9 @@ private:
 	 *
 	 * @param key_id I2C key ID
 	 * @param value configuration value
-	 * @param msg_size CFG-VALSET message size: this is an input & output param
 	 * @return true on success, false if buffer too small
 	 */
-	bool cfgValsetPort(uint32_t key_id, uint8_t value, int &msg_size);
+	bool cfgValsetPort(uint32_t key_id, uint8_t value);
 
 	/**
 	 * Add a port-specific (MSGOUT) configuration value for UART2, which is never the port this
@@ -1184,10 +1182,9 @@ private:
 	 *
 	 * @param key_id I2C key ID
 	 * @param value configuration value
-	 * @param msg_size CFG-VALSET message size: this is an input & output param
 	 * @return true on success, false if buffer too small
 	 */
-	bool cfgValsetUart2(uint32_t key_id, uint8_t value, int &msg_size);
+	bool cfgValsetUart2(uint32_t key_id, uint8_t value);
 
 	/**
 	 * Reset the parse state machine for a fresh start
@@ -1200,10 +1197,15 @@ private:
 	uint32_t fnv1_32_str(uint8_t *str, uint32_t hval);
 
 	/**
-	 * Init _tx_cfg_valset_buf as CFG-VALSET
-	 * @return size of the message (without any config values)
+	 * Start a new CFG-VALSET in _tx_cfg_valset_buf (header only, no config values yet)
 	 */
-	int initCfgValset();
+	void initCfgValset();
+
+	/**
+	 * Send the CFG-VALSET built up by initCfgValset() and cfgValset*() calls
+	 * @return true on success
+	 */
+	bool sendCfgValset();
 
 	/**
 	 * Start or restart the survey-in procees. This is only used in RTCM ouput mode.
@@ -1259,6 +1261,7 @@ private:
 	ubx_ack_state_t         _ack_state{UBX_ACK_IDLE};
 	ubx_buf_t               _buf{};
 	uint8_t                 _tx_cfg_valset_buf[UBX_CFG_VALSET_BUF_SIZE] {};
+	int                     _tx_cfg_valset_size{0};
 	ubx_decode_state_t      _decode_state{};
 	ubx_rxmsg_state_t       _rx_state{UBX_RXMSG_IGNORE};
 


### PR DESCRIPTION
## Summary
Eight mechanical refactors of ubx, nmea, ashtech, femtomes, mtk and gps_helper that together take about 4.2 KB of flash off `px4_fmu-v6x_default` without changing what goes over the wire. Each commit carries its own measurement.

## Problem
Flash is tight on the 2 MB boards and this submodule spends it on repetition: ~250 `cfgValset<T>(KEY, value, msg_size)` calls at 16 B each (the template bodies themselves are only ~320 B), 62 hand-spelled `sendMessage(UBX_MSG_CFG_VALSET, ...)` sends, 125 copies of the NMEA field-read idiom in nmea/ashtech/femtomes at ~28 B each, 14 copies of the ddmm.mmmm conversion, and the mktime / GPS epoch check / setClock block copied six times across four drivers.

## Solution
- ubx: one non-template `cfgValsetRaw()` taking the value width from the key ID's size field (all 249 sites audited to agree with their `T`); the VALSET size lives next to the buffer; `sendCfgValset()` / `sendCfgValsetAcked()` replace the repeated send / wait-for-ACK sequences; fixed port setups, MSM4/MSM7 toggles and RTCM MSGOUT lists become `constexpr` tables beside their use; MON-VER board detection is a table.
- nmea/ashtech/femtomes: `GPSHelper::nmeaNextField()` overloads and `nmeaToDegrees()` replace the inline field reads; ZDA/RMC share `setTimeUtc()`.
- all: `GPSHelper::timeFromUtc()` holds the epoch conversion and clock set once, keeping NMEA's set-the-clock-once behaviour and ubx's signed `nano`.

Verified with two host harnesses built against 836094f and this head: 23 NMEA/Ashtech sentences produce byte-identical `sensor_gps_s` / `satellite_info_s`, and a fake ACKing receiver driven through `configure()` in 26 board/mode combinations (F9P in every `UBXMode` incl. PPK, RTCM base, SPI, u-center; F9P-15B, M9N, M10, F10N, X20, M8 pre-v27) emits identical frames, with CFG-VALSET payloads compared as key/value sets because the table commit reorders keys inside a few messages. Not yet run on hardware.
